### PR TITLE
feat: add resolution filter and image header parsing

### DIFF
--- a/src/main/services/utils.ts
+++ b/src/main/services/utils.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs/promises";
+
+type ImageType = "jpeg" | "png" | "bmp";
+
+const IMAGE_HEADERS_IDENTIFIERS = {
+  jpeg: 0xffd8,
+  png: 0x89504e47,
+  bmp: 0x424d,
+};
+const MAX_BYTES = 8192;
+
+export async function parseImageHeader(imagePath: string) {
+  try {
+    const file = await fs.open(imagePath, "r");
+    const buffer = Buffer.alloc(8192); // 8kb
+    const { bytesRead } = await file.read(buffer, 0, MAX_BYTES, 0);
+    await file.close();
+
+    const res = { height: 0, width: 0 };
+
+    if (matchHeader(buffer, "png")) {
+      // https://en.wikipedia.org/wiki/PNG#Examples
+      const widthOffset = 16;
+      const heightOffset = widthOffset + 4;
+      res.width = buffer.readUInt32BE(widthOffset);
+      res.height = buffer.readUInt32BE(heightOffset);
+    } else if (matchHeader(buffer, "bmp")) {
+      // BMP uses little endian
+      const widthOffset = 18;
+      const heightOffset = widthOffset + 4;
+      res.width = buffer.readUInt32LE(widthOffset);
+      res.height = buffer.readUInt32LE(heightOffset);
+    } else if (matchHeader(buffer, "jpeg")) {
+      // https://stackoverflow.com/questions/14414884
+      let offset = 2;
+      while (offset < bytesRead - 8) {
+        if (buffer[offset] !== 0xff) {
+          offset++;
+          continue;
+        }
+        const marker = buffer[offset + 1];
+
+        if (
+          marker >= 0xc0 &&
+          marker <= 0xcf &&
+          ![0xc4, 0xc8, 0xcc].includes(marker)
+        ) {
+          const heightOffset = offset + 5;
+          const widthOffset = heightOffset + 2;
+          res.height = buffer.readUInt16BE(heightOffset);
+          res.width = buffer.readUInt16BE(widthOffset);
+          break;
+        }
+        offset += 2 + buffer.readUInt16BE(offset + 2); // 2 + length segment, +2 so we skip the marker
+      }
+    }
+
+    return res;
+  } catch (err) {
+    return { height: 0, width: 0 };
+  }
+}
+
+function matchHeader(buffer: Buffer, imageType: ImageType) {
+  switch (imageType) {
+    case "jpeg":
+      return buffer.readUInt16BE(0) === IMAGE_HEADERS_IDENTIFIERS[imageType];
+
+    case "png":
+      return buffer.readUInt32BE(0) === IMAGE_HEADERS_IDENTIFIERS[imageType];
+
+    case "bmp":
+      return buffer.readUInt16BE(0) === IMAGE_HEADERS_IDENTIFIERS[imageType];
+  }
+}

--- a/src/main/services/wallpaper.ts
+++ b/src/main/services/wallpaper.ts
@@ -8,6 +8,7 @@ import { settingsService } from './settings'
 import { storeService } from './store'
 import { STEAM_PATHS, CACHE_TTL, type WallpaperOverrides, type Wallpaper, type ApplyWallpaperOptions } from '../../shared/constants'
 import { CompatibilityService } from './compatibility'
+import { parseImageHeader } from './utils'
 
 const execAsync = promisify(exec)
 
@@ -270,9 +271,10 @@ class WallpaperService {
       const files = await fs.readdir(wallpaperPath)
 
       // Look for video files first
-      const videoFile = files.find(f =>
-        f.endsWith('.mp4') || f.endsWith('.webm') || f.endsWith('.avi') || f.endsWith('.mkv')
-      )
+      const videoFile = files.find(f =>{
+       const file = f.toLowerCase();
+        return file.endsWith('.mp4') || file.endsWith('.webm') || file.endsWith('.avi') || file.endsWith('.mkv')
+      })
 
       if (videoFile) {
         const videoPath = path.join(wallpaperPath, videoFile)
@@ -283,18 +285,15 @@ class WallpaperService {
         }
       } else {
         // Look for image files (excluding preview thumbnails)
-        const imageFile = files.find(f =>
-          (f.endsWith('.png') || f.endsWith('.jpg') || f.endsWith('.jpeg') || f.endsWith('.bmp')) &&
-          !f.toLowerCase().includes('preview')
-        )
+        const imageFile = files.find(f =>{
+          const file = f.toLowerCase()
+          return (file.endsWith('.png') || file.endsWith('.jpg') || file.endsWith('.jpeg') || file.endsWith('.bmp')) &&
+          !file.includes('preview')
+      })
 
         if (imageFile) {
           const imagePath = path.join(wallpaperPath, imageFile)
-          const { stdout } = await execAsync(`file "${imagePath}"`)
-          const match = stdout.match(/(\d+)\s*x\s*(\d+)/)
-          if (match) {
-            return { width: parseInt(match[1], 10), height: parseInt(match[2], 10) }
-          }
+          return parseImageHeader(imagePath);
         }
       }
     } catch {

--- a/src/main/trpc/routes/settings.ts
+++ b/src/main/trpc/routes/settings.ts
@@ -45,6 +45,7 @@ const settingsSchema = z.object({
   // Persisted filter & sort preferences
   filterType: z.array(z.enum(['all', 'scene', 'video', 'web', 'application'])).optional(),
   filterTags: z.array(z.string()).optional(),
+  filterResolution:z.array(z.string()).optional(),
   filterCompatibility: z.array(z.enum(['unknown', 'broken', 'major', 'minor', 'perfect'])).optional(),
   sortBy: z.enum(['name', 'size', 'recent']).optional(),
   sortOrder: z.enum(['asc', 'desc']).optional(),

--- a/src/renderer/components/wallpaper/filters-dropdown.tsx
+++ b/src/renderer/components/wallpaper/filters-dropdown.tsx
@@ -30,6 +30,10 @@ export function FiltersDropdown() {
         toggleTag,
         setFilterTags,
         availableTags,
+        filterResolution,
+        toggleResolution,
+        setFilterResolution,
+        availableResolutions,
         filterCompatibility,
         toggleFilterCompatibility,
         setFilterCompatibility,
@@ -38,11 +42,13 @@ export function FiltersDropdown() {
     const activeFilterCount =
         filterType.length +
         filterTags.length +
+        filterResolution.length +
         filterCompatibility.length
 
     const handleClearAll = (e: React.MouseEvent) => {
         e.stopPropagation()
         setFilterType([])
+        setFilterResolution([])
         setFilterTags([])
         setFilterCompatibility([])
     }
@@ -106,6 +112,19 @@ export function FiltersDropdown() {
                         multi
                         badge={filterTags.length > 0 ? (
                             <span className="text-primary">{filterTags.length} selected</span>
+                        ) : undefined}
+                    />
+                )}
+
+                {availableResolutions.length > 0 && (
+                    <FilterSection
+                        label="Resolution"
+                        items={availableResolutions.map((res) => ({ key: res, label: res }))}
+                        selected={filterResolution}
+                        onToggle={toggleResolution}
+                        multi
+                        badge={filterResolution.length > 0 ? (
+                            <span className="text-primary">{filterResolution.length} selected</span>
                         ) : undefined}
                     />
                 )}

--- a/src/renderer/components/wallpaper/wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid.tsx
@@ -15,7 +15,7 @@ const WallpaperDetails = lazy(() => import("./wallpaper-details").then(m => ({ d
 export function WallpaperGrid() {
     const [selectedWallpaper, setSelectedWallpaper] = useState<Wallpaper | null>(null)
     const [detailsVisible, setDetailsVisible] = useState(false)
-    const { searchQuery, filterType, filterTags, sortBy, sortOrder, setAvailableTags, filterCompatibility } = useSearch()
+    const { searchQuery, filterType, filterTags, filterResolution, sortBy, sortOrder, setAvailableTags, setAvailableResolutions, filterCompatibility } = useSearch()
     const debouncedSearch = useDebounce(searchQuery, 300)
     const { setSelectedUrl } = useWallpaperBackground()
 
@@ -59,13 +59,16 @@ export function WallpaperGrid() {
         const hasTypeFilter = filterType.length > 0
         const typeSet = hasTypeFilter ? new Set(filterType) : null
         const hasTagFilter = filterTags.length > 0
+        const hasResolutionFilter = filterResolution.length > 0
         const hasCompatFilter = filterCompatibility.length > 0 && compatibilityMap
         const compatSet = hasCompatFilter ? new Set(filterCompatibility) : null
 
-        if (hasTypeFilter || hasTagFilter || hasCompatFilter) {
+        if (hasTypeFilter || hasTagFilter || hasCompatFilter || hasResolutionFilter) {
             result = result.filter(w => {
                 if (typeSet && !typeSet.has(w.type)) return false
-                if (hasTagFilter && !filterTags.some(tag => w.tags?.includes(tag))) return false
+                if (hasTagFilter && !filterTags.some(tag => w.tags?.includes(tag))) return false 
+                if (hasResolutionFilter && !filterResolution.includes(!w.resolution.height || !w.resolution.width ? "Unknown" :`${w.resolution.width}x${w.resolution.height}`)) return false
+                
                 if (compatSet && compatibilityMap) {
                     const status = compatibilityMap[w.path ?? ''] ?? 'unknown'
                     if (!compatSet.has(status)) return false
@@ -97,7 +100,7 @@ export function WallpaperGrid() {
         })
 
         return result
-    }, [data, filterType, filterTags, sortBy, sortOrder, filterCompatibility, compatibilityMap])
+    }, [data, filterType, filterTags, filterResolution, sortBy, sortOrder, filterCompatibility, compatibilityMap])
 
     // Sync selected wallpaper thumbnail as blurred page background
     useEffect(() => {
@@ -108,11 +111,36 @@ export function WallpaperGrid() {
     // Extract and set available tags from raw data (before filtering)
     useEffect(() => {
         if (!data) return
-        const allTags = data.flatMap(w => w.tags ?? [])
-        const uniqueTags = [...new Set(allTags)].sort()
-        setAvailableTags(uniqueTags)
-    }, [data, setAvailableTags])
 
+    const { tags, resolutions } = wallpapers.reduce((acc, item) => {
+    
+       item.tags &&  acc.tags.push(...item.tags);
+
+       
+            acc.resolutions.push(!item.resolution.height || !item.resolution.width ? "Unknown" :`${item.resolution.width}x${item.resolution.height}`);
+
+        return acc;
+      },
+      {
+        tags: [] as string[],
+        resolutions: [] as string[],
+      },
+    );
+
+
+        const uniqueTags = [...new Set(tags)].sort()
+        const uniqueResolutions = [...new Set(resolutions)].sort((a,b)=>{
+            if(a === "Unknown") return -1
+            if(b === "Unknown") return 1
+            
+            const [widthA, heightA] = a.split('x')
+            const [widthB, heightB] = b.split('x')
+            return parseInt(widthB) * parseInt(heightB) - parseInt(widthA) * parseInt(heightA)
+    })
+        setAvailableTags(uniqueTags)
+        setAvailableResolutions(uniqueResolutions)
+        
+    }, [data, setAvailableTags,setAvailableResolutions])
 
     
     const toggleWallpaper = useCallback((w: Wallpaper) => {

--- a/src/renderer/contexts/search-context.tsx
+++ b/src/renderer/contexts/search-context.tsx
@@ -40,6 +40,11 @@ interface FilterContextType {
   toggleTag: (tag: string) => void
   availableTags: string[]
   setAvailableTags: (tags: string[]) => void
+  filterResolution: string[]
+  setFilterResolution: (resolutions: string[]) => void
+  toggleResolution: (res: string) => void
+  availableResolutions: string[]
+  setAvailableResolutions: (resolutions: string[]) => void
   filterCompatibility: CompatibilityStatus[]
   setFilterCompatibility: (statuses: CompatibilityStatus[]) => void
   toggleFilterCompatibility: (status: CompatibilityStatus) => void
@@ -57,6 +62,8 @@ export function SearchProvider({ children }: { children: ReactNode }) {
   const [filterType, setFilterType] = useState<WallpaperFilterType[]>([])
   const [filterTags, setFilterTags] = useState<string[]>([])
   const [availableTags, setAvailableTags] = useState<string[]>([])
+  const [filterResolution, setFilterResolution] = useState<string[]>([])
+  const [availableResolutions, setAvailableResolutions] = useState<string[]>([])
   const [sortBy, setSortBy] = useState<SortBy>("name")
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc")
   const [filterCompatibility, setFilterCompatibility] = useState<CompatibilityStatus[]>([])
@@ -67,6 +74,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     if (settings && !initialized) {
       setFilterType(settings.filterType ?? [])
       setFilterTags(settings.filterTags)
+      setFilterResolution(settings.filterResolution)
       setFilterCompatibility(settings.filterCompatibility)
       setSortBy(settings.sortBy)
       setSortOrder(settings.sortOrder)
@@ -137,6 +145,22 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     })
   }, [persist])
 
+  const handleSetFilterResolution = useCallback((resolutions: string[]) => {
+    setFilterResolution(resolutions)
+    persist({ filterResolution: resolutions })
+  }, [persist])
+
+  const handleToggleResolution = useCallback((res: string) => {
+    setFilterResolution(prev => {
+      const next = prev.includes(res)
+        ? prev.filter(r => r !== res)
+        : [...prev, res]
+      persist({ filterResolution: next })
+      return next
+    })
+    
+  }, [persist])
+
   const handleSetFilterCompatibility = useCallback((statuses: CompatibilityStatus[]) => {
     setFilterCompatibility(statuses)
     persist({ filterCompatibility: statuses })
@@ -161,11 +185,17 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     toggleTag: handleToggleTag,
     availableTags,
     setAvailableTags,
+    filterResolution,
+    setFilterResolution: handleSetFilterResolution,
+    toggleResolution: handleToggleResolution,
+    availableResolutions,
+    setAvailableResolutions,
     filterCompatibility,
     setFilterCompatibility: handleSetFilterCompatibility,
     toggleFilterCompatibility: handleToggleFilterCompatibility,
-  }), [filterType, filterTags, availableTags, filterCompatibility, handleSetFilterType, handleToggleFilterType, handleSetFilterTags, handleToggleTag, handleSetFilterCompatibility, handleToggleFilterCompatibility])
+  }), [filterType, filterTags,filterResolution, availableTags,availableResolutions,filterResolution, filterCompatibility, handleSetFilterType, handleToggleFilterType, handleSetFilterTags,handleSetFilterResolution, handleToggleTag,handleToggleResolution, handleSetFilterCompatibility, handleToggleFilterCompatibility])
 
+  
   return (
     <SearchQueryContext.Provider value={searchQueryValue}>
       <SortContext.Provider value={sortValue}>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -97,6 +97,8 @@ export interface AppSettings {
   // Persisted filter & sort preferences
   filterType: WallpaperFilterType[]
   filterTags: string[]
+  filterResolution:string[]
+
   filterCompatibility: CompatibilityStatus[]
   sortBy: SortBy
   sortOrder: SortOrder
@@ -138,6 +140,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // Filters & sort
   filterType: [],
   filterTags: [],
+  filterResolution:[],
   filterCompatibility: [],
   sortBy: 'name',
   sortOrder: 'asc',


### PR DESCRIPTION
Added a resolution filter since I have around 600 wallpapers for multiple monitors and it was getting hard to manage 😅

Changed `detectResolution` to parse image headers instead of spawning a shell process.  Some JPEGs have embedded preview image, so the `file` command was detecting the preview resolution instead of the actual one.  I wasn’t sure about adding new deps, so I implemented a small header parser.

the detection for non image/video wallpapers is still not perfect. Maybe we could use the Steam API and the local as fallback?