### PR TITLE
feat: tray and minimize [JAG-26]

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,10 +1,24 @@
-import { app, BrowserWindow, protocol, net } from 'electron'
+import { app, protocol, net, BrowserWindow, Tray, Menu } from 'electron'
 import path from 'node:path'
 import { createIPCHandler } from 'trpc-electron/main'
 import { createTrpcContext } from './trpc/context.ts'
 import { appRouter } from './trpc/router.ts'
 import { settingsService } from './services/settings.ts'
 import { setFlatpakBypass } from './services/flatpak.ts'
+
+// Global ref to tray to avoid GC
+let tray: Tray | null = null
+let isQuitting: boolean = false
+
+const iconPath: string = path.join(__dirname, '../../assests/transperent-logo.png')
+
+const shouldMinimizeOnClose = (): boolean => {
+  return settingsService.getSetting('enableSystemTray') && settingsService.getSetting('minimizeOnClose')
+}
+
+const shouldMinimizeOnStartup = (): boolean => {
+  return settingsService.getSetting('enableSystemTray') && settingsService.getSetting('minimizeOnStartup')
+}
 
 // Register the local-file protocol for serving local wallpaper images
 protocol.registerSchemesAsPrivileged([
@@ -27,7 +41,7 @@ const createWindow = () => {
     show: false,
     backgroundColor: '#09090b',
     autoHideMenuBar: true,
-    icon: path.join(__dirname, '../../assests/transperent-logo.png'),
+    icon: iconPath,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -36,7 +50,7 @@ const createWindow = () => {
   })
 
   mainWindow.once('ready-to-show', () => {
-    mainWindow.show()
+    if (!shouldMinimizeOnStartup()) mainWindow.show()
   })
 
   // and load the index.html of the app.
@@ -52,6 +66,38 @@ const createWindow = () => {
   // mainWindow.webContents.openDevTools()
 
   return mainWindow
+}
+
+// Initialize the system tray with context menu
+const initializeTray = (mainWindow: BrowserWindow): void => {
+  if (tray !== null) return
+  tray = new Tray(iconPath)
+
+  const toggleMainWindow = (): void => {
+    if (!mainWindow.isVisible()) {
+      mainWindow.show()
+    } else if (!mainWindow.isFocused()) {
+      mainWindow.focus()
+    }
+  }
+
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Toggle App',
+      click: toggleMainWindow
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        app.quit()
+      }
+    }
+  ])
+
+  tray.setToolTip(mainWindow.title)
+  tray.setContextMenu(contextMenu)
+  tray.on('click', toggleMainWindow)
 }
 
 // This method will be called when Electron has finished
@@ -70,11 +116,15 @@ app.whenReady().then(() => {
 
   const mainWindow = createWindow()
 
+  if (settingsService.getSetting('enableSystemTray'))
+    initializeTray(mainWindow)
+
   mainWindow.on('close', (e) => {
-    const minimizeOnClose = settingsService.getSetting('minimizeOnClose')
-    if (minimizeOnClose) {
+    if (shouldMinimizeOnClose() && !isQuitting) {
       e.preventDefault()
       mainWindow.hide()
+      if (tray === null)
+        initializeTray(mainWindow)
     }
   })
 
@@ -85,12 +135,20 @@ app.whenReady().then(() => {
   })
 })
 
+// Dispose tray before quitting
+app.on('before-quit', () => {
+  isQuitting = true
+  if (tray) {
+    tray.destroy()
+    tray = null
+  }
+})
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  const minimizeOnClose = settingsService.getSetting('minimizeOnClose')
-  if (process.platform !== 'darwin' && !minimizeOnClose) {
+  if (process.platform !== 'darwin' && !shouldMinimizeOnClose()) {
     app.quit()
   }
 })

--- a/src/main/trpc/routes/settings.ts
+++ b/src/main/trpc/routes/settings.ts
@@ -33,6 +33,8 @@ const settingsSchema = z.object({
   // App
   theme: z.enum(THEME_OPTIONS.map(o => o.value) as [ThemeOption, ...ThemeOption[]]).optional(),
   launchOnLogin: z.boolean().optional(),
+  enableSystemTray: z.boolean().optional(),
+  minimizeOnStartup: z.boolean().optional(),
   minimizeOnClose: z.boolean().optional(),
   restoreLastWallpaper: z.boolean().optional(),
   lastWallpaperId: z.string().nullable().optional(),

--- a/src/renderer/components/settings/setting-row.tsx
+++ b/src/renderer/components/settings/setting-row.tsx
@@ -5,22 +5,24 @@ import { cn } from "@/lib/utils"
 interface SettingRowProps {
     label: string
     children: React.ReactNode
+    disabled?: boolean
     changed?: boolean
     onClear?: () => void
 }
 
-export function SettingRow({ label, children, changed, onClear }: SettingRowProps) {
+export function SettingRow({ label, children, disabled, changed, onClear }: SettingRowProps) {
     return (
         <div
             className={cn(
                 "flex items-center justify-between px-4 py-3 transition-colors rounded-md",
+                disabled && "opacity-50 grayscale-[0.5] cursor-not-allowed select-none",
                 changed && "bg-primary/10 ring-1 ring-primary/30"
             )}
         >
             <span className="text-sm">{label}</span>
             <div className="flex items-center gap-2">
                 {children}
-                {changed && onClear && (
+                {changed && onClear && !disabled && (
                     <button
                         onClick={onClear}
                         className="text-muted-foreground hover:text-foreground transition-colors"

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -143,12 +143,30 @@ function SettingsPage() {
                             onCheckedChange={(checked) => updateSetting("launchOnLogin", checked)}
                         />
                     </SettingRow>
-                    {/* <SettingRow label="Minimize on close">
+                    <SettingRow label="Enable system tray">
+                        <Switch
+                            checked={settings.enableSystemTray}
+                            onCheckedChange={(checked) => updateSetting("enableSystemTray", checked)}
+                        />
+                    </SettingRow>
+                    <SettingRow
+                        label="Minimize on startup"
+                        disabled={!settings.launchOnLogin || !settings.enableSystemTray}
+                    >
+                        <Switch
+                            checked={settings.minimizeOnStartup}
+                            onCheckedChange={(checked) => updateSetting("minimizeOnStartup", checked)}
+                        />
+                    </SettingRow>
+                    <SettingRow
+                        label="Minimize on close"
+                        disabled={!settings.enableSystemTray}
+                    >
                         <Switch
                             checked={settings.minimizeOnClose}
                             onCheckedChange={(checked) => updateSetting("minimizeOnClose", checked)}
                         />
-                    </SettingRow> */}
+                    </SettingRow>
                 </SettingsSection>
 
                 {/* Compatibility Scan Section */}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -84,6 +84,8 @@ export interface AppSettings {
   // App settings (not backend, managed by our app)
   theme: ThemeOption
   launchOnLogin: boolean
+  enableSystemTray: boolean
+  minimizeOnStartup: boolean
   minimizeOnClose: boolean
   restoreLastWallpaper: boolean
   lastWallpaperId: string | null
@@ -131,6 +133,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // App
   theme: 'system',
   launchOnLogin: false,
+  enableSystemTray: false,
+  minimizeOnStartup: false,
   minimizeOnClose: false,
   restoreLastWallpaper: true,
   lastWallpaperId: null,


### PR DESCRIPTION
Implemented 3 settings:

- Enable system tray
- Minimize on startup (must enable launch at startup and system tray)
- Minimize on close (must enable system tray)

Minimized options are disabled and greyed out when those conditions aren't met. Let me know if this seems intuitive.