### PR TITLE
fix: normalise steamuser config structure to prevent playlist creation crash

### DIFF
--- a/src/main/services/playlist.ts
+++ b/src/main/services/playlist.ts
@@ -92,8 +92,12 @@ class PlaylistService {
       parsed.steamuser.general ??= { playlists: [] }
       parsed.steamuser.general.playlists ??= []
       return parsed
-    } catch {
-      return defaultConfig
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return defaultConfig
+      }
+
+      throw error
     }
   }
 


### PR DESCRIPTION
Fixes "Cannot read properties of undefined (reading 'general')" when creating playlists on machines where the Wallpaper Engine config.json exists but lacks the steamuser.general keys.

Closes #21

Generated with [Claude Code](https://claude.ai/code)