### PR TITLE
nix: simpler shell setup + devshell docs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,18 +19,13 @@ Thanks for your interest in contributing! For bug reports and feature requests, 
 - [linux-wallpaperengine](https://github.com/Almamu/linux-wallpaperengine) installed and binary accessible in your `$PATH`
 - [Wallpaper Engine](https://store.steampowered.com/app/431960/Wallpaper_Engine/) installed on Steam with wallpapers downloaded
 
+For Nix, refer to the [devshell](#nix-devshell) section.
 
 ### Development Setup
 
 ```bash
 git clone https://github.com/jagrat7/linux-wallpaper-engine.git
 cd linux-wallpaper-engine
-```
-
-(Optional) For Nix ONLY, you can enter the dev shell that will set up bun + electron for you:
-
-```bash
-nix develop
 ```
 
 Then, on any distro, proceed to:
@@ -48,7 +43,25 @@ bun run make
 
 Builds packages for your current platform using Electron Forge. Build configuration is in `forge.config.ts`. The results will be in the `out/` directory.
 
-For Nix, you'll have to build the flake package with:
+### Nix Devshell
+
+As with the installation setup, flakes must be enabled. With [nix-direnv](https://github.com/nix-community/nix-direnv), it's as simple as getting in to the project root and allowing it.
+
+```bash
+cd linux-wallpaper-engine
+direnv allow
+```
+
+Now, every time you cd into the repo, you should be in the devshell with all the necessary dependencies and packaging set up. If not using direnv, you can access the devshell with:
+
+```bash
+nix develop
+
+# you can also pass commands without entering the devshell
+nix develop -c bun start
+```
+
+In the devshell, you can run the make targets to package for other platforms. To build specifically for Nix, you'll have to build the flake output package:
 
 ```bash
 # nix build, but with prettier output
@@ -58,7 +71,7 @@ nom build
 ./result/bin/linux-wallpaper-engine
 ```
 
-The Nix dev shell should be able to run the make targets as well, if packaging for other distros.
+> NOTE: For non-NixOS systems, there's currently a limitation when it comes to graphics drivers for Electron.
 
 
 ## Project Structure

--- a/.gitignore
+++ b/.gitignore
@@ -94,8 +94,10 @@ out/
 # Nix build output symlink
 result*
 
-# CLAUDE.md
+# Direnv
+.direnv/
 
+# CLAUDE.md
 
 .claude 
 
@@ -110,5 +112,6 @@ demo-video/
 docs/demo-video-tool.md
 
 docs/testing.md
+
 # CocoIndex Code (ccc)
 /.cocoindex_code/

--- a/distro/nix/shell.nix
+++ b/distro/nix/shell.nix
@@ -73,13 +73,13 @@ mkShell {
         # Do not download unpatched Electron
         export ELECTRON_SKIP_BINARY_DOWNLOAD=1
 
-        # Instead create an override in tmp with symlinks
-        export ELECTRON_OVERRIDE_DIST_PATH="/tmp/${package.name}-electron"
-        mkdir -p "$ELECTRON_OVERRIDE_DIST_PATH"
+        # Instead create an override with symlinks
+        export ELECTRON_OVERRIDE_DIR="$DEV_TEMP_DIR/${package.name}-electron"
+        mkdir -p "$ELECTRON_OVERRIDE_DIR"
 
-        ln -snf ${electron}/bin/electron "$ELECTRON_OVERRIDE_DIST_PATH/electron"
-        ln -snf ${electron}/libexec/electron/resources "$ELECTRON_OVERRIDE_DIST_PATH/resources"
-        ln -snf ${electron}/libexec/electron/locales "$ELECTRON_OVERRIDE_DIST_PATH/locales"
+        ln -snf ${electron}/bin/electron "$ELECTRON_OVERRIDE_DIR/electron"
+        ln -snf ${electron}/libexec/electron/resources "$ELECTRON_OVERRIDE_DIR/resources"
+        ln -snf ${electron}/libexec/electron/locales "$ELECTRON_OVERRIDE_DIR/locales"
       '';
 
       mkWraperForRpm =
@@ -130,7 +130,7 @@ mkShell {
       rpmOnNixHack = ''
         # bash
         # Workaround for RPM's hardcoded reliance on global system state
-        export RPM_WRAPPER_DIR="/tmp/${package.name}-rpmbuild"
+        export RPM_WRAPPER_DIR="$DEV_TEMP_DIR/${package.name}-rpmbuild"
         export LOCAL_RPM_DB="$RPM_WRAPPER_DIR/rpmdb"
 
         mkdir -p "$RPM_WRAPPER_DIR/bin"
@@ -142,34 +142,13 @@ mkShell {
         # Prepend our wrapped binaries so they override
         export PATH="$RPM_WRAPPER_DIR/bin:$PATH"
       '';
-
-      userShell = ''
-        # bash
-        # Clean up on exit
-        CLEANUP_CMD="rm -rf $ELECTRON_OVERRIDE_DIST_PATH $RPM_WRAPPER_DIR"
-
-        # Find user's shell if set, since $SHELL gets stripped
-        if command -v getent >/dev/null 2>&1; then
-          USER_SHELL=$(getent passwd "$USER" | cut -d: -f7)
-        elif [ -f /etc/passwd ]; then
-          USER_SHELL=$(grep "^$USER:" /etc/passwd | cut -d: -f7)
-        fi
-
-        # Run preferred shell if found and in interactive mode
-        if [[ -n "$USER_SHELL" && "$USER_SHELL" != *"bash"* && $- == *i* ]]; then
-          "$USER_SHELL"
-          eval "$CLEANUP_CMD"
-          exit
-
-        # If falling back to bash, use a trap to clean up on exit
-        else
-          trap "$CLEANUP_CMD" EXIT
-        fi
-      '';
     in
     ''
+      # bash
+      PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+      export DEV_TEMP_DIR="$PROJECT_ROOT/.direnv/tmp"
+      mkdir -p "$DEV_TEMP_DIR"
       ${electronOffline}
       ${rpmOnNixHack}
-      ${userShell}
     '';
 }


### PR DESCRIPTION
I swear this has to be the final change for the devshell!

The user shell part the hook I previously wrote was just unnecessary and caused more issues than it should have. I found direnv to be a better solution than whatever I came up with that makes setup even better with one less command (no need for `nix develop`, just `cd` to the project after it's been allowed). It's also not a strict prerequisite, anyone on Nix can still just use the `nix develop` normally.

I've also went ahead and tidied up the Nix documentation for contributing, separating it to its own section, with an added a note for the graphics drivers problem for non-NixOS systems. I'll probably investigate that next and see if there's something that could be done about it.