### PR TITLE
Fix apply button showing active state on wallpaper failure

### DIFF
--- a/src/renderer/components/wallpaper/apply-button.tsx
+++ b/src/renderer/components/wallpaper/apply-button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Monitor, Loader2, ChevronDown, Square } from "lucide-react"
+import { Monitor, Loader2, ChevronDown, Square, AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
     DropdownMenu,
@@ -16,6 +16,7 @@ interface ApplyButtonProps {
     onStop?: (screen?: string) => Promise<void>
     isApplying: boolean
     isActive?: boolean
+    error?: string | null
     label?: string
     applyingLabel?: string
     size?: "default" | "sm" | "lg" | "icon" | "icon-sm"
@@ -27,11 +28,13 @@ export function ApplyButton({
     onStop,
     isApplying,
     isActive = false,
+    error,
     label = "Apply",
     applyingLabel = "Applying...",
     size = "default",
     className,
 }: ApplyButtonProps) {
+    const hasError = !!error && !isApplying
     const { data: displays } = trpc.display.list.useQuery()
 
     return (
@@ -39,33 +42,38 @@ export function ApplyButton({
             <div className="flex">
                 <Button
                     size={size}
-                    variant={isActive ? "outline" : "default"}
+                    variant={isActive ? "outline" : hasError ? "outline" : "default"}
                     className={cn(
                         "gap-2 rounded-r-none flex-1",
-                        isActive && "text-destructive hover:bg-destructive/10 hover:text-destructive"
+                        isActive && "text-destructive hover:bg-destructive/10 hover:text-destructive",
+                        hasError && "border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"
                     )}
                     onClick={() => isActive && onStop ? onStop() : onApply()}
                     disabled={isApplying}
                 >
                     {isApplying ? (
                         <Loader2 className="size-4 animate-spin" />
+                    ) : hasError ? (
+                        <AlertCircle className="size-4" />
                     ) : isActive ? (
                         <Square className="size-4" />
                     ) : (
                         <Monitor className="size-4" />
                     )}
-                    {isApplying ? applyingLabel : isActive ? "Stop" : label}
+                    {isApplying ? applyingLabel : hasError ? "Failed" : isActive ? "Stop" : label}
                 </Button>
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                         <Button
                             size={size}
-                            variant={isActive ? "outline" : "default"}
+                            variant={isActive ? "outline" : hasError ? "outline" : "default"}
                             className={cn(
                                 "rounded-l-none border-l px-2",
                                 isActive
                                     ? "text-destructive hover:bg-destructive/10 hover:text-destructive"
-                                    : "border-primary-foreground/20"
+                                    : hasError
+                                        ? "border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"
+                                        : "border-primary-foreground/20"
                             )}
                             disabled={isApplying}
                         >
@@ -97,6 +105,9 @@ export function ApplyButton({
                     </DropdownMenuContent>
                 </DropdownMenu>
             </div>
+            {hasError && (
+                <p className="mt-1.5 text-xs text-destructive">{error}</p>
+            )}
         </div>
     )
 }

--- a/src/renderer/components/wallpaper/wallpaper-details.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-details.tsx
@@ -33,6 +33,7 @@ interface WallpaperDetailsProps {
 
 export function WallpaperDetails({ wallpaper, onClose }: WallpaperDetailsProps) {
     const [isApplying, setIsApplying] = useState(false)
+    const [applyError, setApplyError] = useState<string | null>(null)
     const [debugScreen, setDebugScreen] = useState<string | null>(null)
     const applyMutation = trpc.wallpaper.setWallpaper.useMutation()
     const stopMutation = trpc.wallpaper.stopWalpaper.useMutation()
@@ -51,15 +52,22 @@ export function WallpaperDetails({ wallpaper, onClose }: WallpaperDetailsProps) 
     const handleApply = async (screen?: string) => {
         if (!wallpaper.path && !wallpaper.id) return
         setIsApplying(true)
+        setApplyError(null)
         try {
             const result = await applyMutation.mutateAsync({
-                backgroundId: wallpaper.path || wallpaper.id,
+                backgroundId: wallpaper.path ?? wallpaper.id,
                 screen,
             })
+
+            if (!result.success) {
+                setApplyError(result.error ?? "Failed to apply wallpaper")
+                return
+            }
+
             await utils.wallpaper.getActiveWallpaper.invalidate()
             await utils.playlist.active.invalidate()
 
-            if (settings?.debugMode && result.success) {
+            if (settings?.debugMode) {
                 // Determine the screen key used by the backend
                 const displays = utils.display.list.getData()
                 const primary = displays?.find(d => d.primary) ?? displays?.[0]
@@ -110,6 +118,7 @@ export function WallpaperDetails({ wallpaper, onClose }: WallpaperDetailsProps) 
                         onStop={handleStop}
                         isApplying={isApplying}
                         isActive={isActive}
+                        error={applyError}
                         className="w-full"
                     />
                 </div>


### PR DESCRIPTION
## Summary
- Check `result.success` before invalidating active wallpaper queries in `handleApply`, preventing the UI from falsely marking a failed wallpaper as applied
- Add `applyError` state to `wallpaper-details.tsx` that captures the error message when apply fails, and clears it on retry
- Add error visual feedback to `ApplyButton` component: red-tinted outline variant with `AlertCircle` icon, "Failed" label, and inline error message text

## Test plan
- [ ] Apply a wallpaper that is known to fail (e.g. incompatible type) and verify the button shows "Failed" with a red outline and the error message appears below
- [ ] Verify the button resets to normal "Apply" state when clicking it again to retry
- [ ] Verify successful wallpaper apply still works as before (button shows active/stop state)
- [ ] Verify the per-screen dropdown buttons also reflect the error styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)