### PR TITLE
Add disable particles and custom wallpaper properties

### DIFF
--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -416,6 +416,7 @@ class WallpaperService implements IWallpaperService {
         scaling: baseOptions.scaling && baseOptions.scaling !== 'default' ? baseOptions.scaling : settings.defaultScaling,
         disableMouse: settings.disableMouse,
         disableParallax: settings.disableParallax,
+        disableParticles: settings.disableParticles,
         noFullscreenPause: !settings.pauseOnFullscreen,
       }
 
@@ -501,7 +502,9 @@ class WallpaperService implements IWallpaperService {
       : options.noAudioProcessing
     const disableMouse = overrides.disableMouse ?? options.disableMouse
     const disableParallax = overrides.disableParallax ?? options.disableParallax
+    const disableParticles = overrides.disableParticles ?? options.disableParticles
     const scaling = overrides.scaling ?? options.scaling
+    const customProperties = overrides.customProperties ?? []
 
     if (options.silent) {
       args.push('--silent')
@@ -514,8 +517,12 @@ class WallpaperService implements IWallpaperService {
     if (options.fps) args.push('--fps', options.fps.toString())
     if (disableMouse) args.push('--disable-mouse')
     if (disableParallax) args.push('--disable-parallax')
+    if (disableParticles) args.push('--disable-particles')
     if (options.noFullscreenPause) args.push('--no-fullscreen-pause')
     if (scaling && scaling !== 'default') args.push('--scaling', scaling)
+    for (const prop of customProperties) {
+      args.push('--set-property', prop)
+    }
 
     return args
   }

--- a/src/main/trpc/routes/settings.ts
+++ b/src/main/trpc/routes/settings.ts
@@ -13,7 +13,7 @@ import { setAutostart } from '../../utils/autostart'
 // Keys that affect the wallpaper backend process and require reapply
 const BACKEND_KEYS = new Set([
   'fps', 'pauseOnFullscreen', 'volume', 'silent', 'noAutomute',
-  'audioProcessing', 'defaultScaling', 'disableMouse', 'disableParallax', 'assetsDir',
+  'audioProcessing', 'defaultScaling', 'disableMouse', 'disableParallax', 'disableParticles', 'assetsDir',
 ])
 
 const settingsSchema = z.object({
@@ -31,6 +31,7 @@ const settingsSchema = z.object({
   defaultScaling: z.enum(SCALING_OPTIONS.map(o => o.value) as [ScalingOption, ...ScalingOption[]]).optional(),
   disableMouse: z.boolean().optional(),
   disableParallax: z.boolean().optional(),
+  disableParticles: z.boolean().optional(),
 
   // Paths
   assetsDir: z.string().nullable().optional(),

--- a/src/main/trpc/routes/wallpaper.ts
+++ b/src/main/trpc/routes/wallpaper.ts
@@ -52,6 +52,7 @@ export const wallpaperRouter = trpc.router({
         noAudioProcessing: z.boolean().optional(),
         disableMouse: z.boolean().optional(),
         disableParallax: z.boolean().optional(),
+        disableParticles: z.boolean().optional(),
         noFullscreenPause: z.boolean().optional(),
         windowed: z
           .object({
@@ -77,6 +78,7 @@ export const wallpaperRouter = trpc.router({
         noAudioProcessing: input.noAudioProcessing ?? !settings.audioProcessing,
         disableMouse: input.disableMouse ?? settings.disableMouse,
         disableParallax: input.disableParallax ?? settings.disableParallax,
+        disableParticles: input.disableParticles ?? settings.disableParticles,
         noFullscreenPause: input.noFullscreenPause ?? !settings.pauseOnFullscreen,
         windowed: input.windowed,
       }
@@ -120,6 +122,8 @@ export const wallpaperRouter = trpc.router({
           scaling: z.enum(['default', 'stretch', 'fit', 'fill']).optional(),
           disableMouse: z.boolean().optional(),
           disableParallax: z.boolean().optional(),
+          disableParticles: z.boolean().optional(),
+          customProperties: z.array(z.string()).optional(),
         }),
       }),
     )

--- a/src/renderer/components/wallpaper/wallpaper-overrides.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-overrides.tsx
@@ -77,6 +77,7 @@ export function WallpaperOverrides({ wallpaper }: WallpaperOverridesProps) {
             scaling: settings.defaultScaling,
             disableMouse: settings.disableMouse,
             disableParallax: settings.disableParallax,
+            disableParticles: settings.disableParticles,
         }
         return map[key]
     }
@@ -173,6 +174,39 @@ export function WallpaperOverrides({ wallpaper }: WallpaperOverridesProps) {
                             onCheckedChange={(checked) => updateOverride("disableParallax", checked)}
                         />
                     </SettingRow>
+
+                    {/* Disable particles */}
+                    <SettingRow
+                        label="Disable particles"
+                        changed={getValue("disableParticles") !== undefined}
+                        onClear={() => clearOverride("disableParticles")}
+                    >
+                        <Switch
+                            checked={getValue("disableParticles") ?? (getGlobalValue("disableParticles") as boolean | undefined) ?? false}
+                            onCheckedChange={(checked) => updateOverride("disableParticles", checked)}
+                        />
+                    </SettingRow>
+
+                    {/* Custom properties */}
+                    <SettingRow
+                        label="Custom properties"
+                        changed={getValue("customProperties") !== undefined && (getValue("customProperties") as string[] | undefined)?.length !== 0}
+                        onClear={() => clearOverride("customProperties")}
+                    >
+                        <textarea
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            rows={3}
+                            placeholder={"key=value\nkey2=value2"}
+                            value={(getValue("customProperties") ?? []).join("\n")}
+                            onChange={(e) => {
+                                const lines = e.target.value.split("\n").filter((l) => l.trim() !== "")
+                                updateOverride("customProperties", lines.length > 0 ? lines : undefined)
+                            }}
+                        />
+                    </SettingRow>
+                    <p className="px-1 text-xs text-muted-foreground">
+                        One property per line using key=value format. Passed as --set-property flags.
+                    </p>
 
                     {hasOverrides && (
                         <Button

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -273,6 +273,12 @@ function SettingsPage() {
                             onCheckedChange={(checked) => updateSetting("disableParallax", checked)}
                         />
                     </SettingRow>
+                    <SettingRow label="Disable particles">
+                        <Switch
+                            checked={settings.disableParticles}
+                            onCheckedChange={(checked) => updateSetting("disableParticles", checked)}
+                        />
+                    </SettingRow>
                 </SettingsSection>
 
                 {/* Appearance Section */}

--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -20,6 +20,7 @@ export interface AppSettings {
   defaultScaling: ScalingOption
   disableMouse: boolean
   disableParallax: boolean
+  disableParticles: boolean
 
   // Paths (backend supported)
   assetsDir: string | null
@@ -69,6 +70,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   defaultScaling: 'fill',
   disableMouse: false,
   disableParallax: false,
+  disableParticles: false,
 
   // Paths
   assetsDir: null,

--- a/src/shared/constants/wallpaper.ts
+++ b/src/shared/constants/wallpaper.ts
@@ -46,6 +46,7 @@ export interface ApplyWallpaperOptions {
   noAudioProcessing?: boolean
   disableMouse?: boolean
   disableParallax?: boolean
+  disableParticles?: boolean
   noFullscreenPause?: boolean
   windowed?: { x: number; y: number; width: number; height: number }
 }
@@ -57,6 +58,8 @@ export interface WallpaperOverrides {
   scaling?: ScalingOption
   disableMouse?: boolean
   disableParallax?: boolean
+  disableParticles?: boolean
+  customProperties?: string[]
   compatibility?: CompatibilityStatus
   autoErrors?: string[]
   lastTested?: number


### PR DESCRIPTION
## Summary
- Add `disableParticles` global setting (Display section) and per-wallpaper override, passing `--disable-particles` flag to linux-wallpaperengine
- Add `customProperties` per-wallpaper override allowing arbitrary `--set-property key=value` flags to be passed to the backend
- Both features integrated into settings UI, wallpaper overrides panel, tRPC schemas, and CLI args builder

## Test plan
- [ ] Verify "Disable particles" toggle appears in Settings > Display section and persists across restarts
- [ ] Verify toggling "Disable particles" in global settings triggers wallpaper reapply with `--disable-particles` flag
- [ ] Verify per-wallpaper "Disable particles" toggle in wallpaper overrides panel works and overrides the global setting
- [ ] Verify "Custom properties" textarea in wallpaper overrides accepts `key=value` entries (one per line) and passes them as `--set-property` flags
- [ ] Verify clearing overrides removes the per-wallpaper flags and falls back to global settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
