### PR TITLE
Fix auto-compatibility bug

### DIFF
--- a/src/main/services/compatibility.ts
+++ b/src/main/services/compatibility.ts
@@ -8,6 +8,7 @@ import {
   BROKEN_PATTERNS,
   MINOR_PATTERNS,
   COMPAT_IGNORE_PATTERNS,
+  COMPATIBILITY_SEVERITY,
 } from '../../shared/constants/compatibility'
 import { storeService } from './store'
 import { invalidationService } from './invalidation'
@@ -76,21 +77,22 @@ class CompatibilityService {
       })
     }
 
-    proc.on('exit', (code) => {
-      clearTimeout(silenceTimer)
-      if (code !== null && code !== 0) {
-        classify(true)
-      }
+    proc.on('exit', (_code, signal) => {
+      if (signal) return
+      classify(true)
     })
-
-    // No stderr at all → classify as perfect
-    const silenceTimer = setTimeout(() => classify(false), 3500)
   }
 
   private updateAutoCompatibility(wallpaperPath: string, status: CompatibilityStatus, errors: string[]): void {
     const all = this.overridesStore.get('overrides')
     const existing = all[wallpaperPath] ?? {}
-    if (existing.compatibility) return
+    const existingCompatibility = existing.compatibility
+    const hasAutoResult = existing.autoErrors !== undefined
+    const shouldUpdate = !existingCompatibility
+      || (hasAutoResult && COMPATIBILITY_SEVERITY[status] > COMPATIBILITY_SEVERITY[existingCompatibility])
+
+    if (!shouldUpdate) return
+
     all[wallpaperPath] = {
       ...existing,
       compatibility: status,
@@ -104,8 +106,11 @@ class CompatibilityService {
   setCompatibility(wallpaperPath: string, status: CompatibilityStatus): void {
     const all = this.overridesStore.get('overrides')
     const existing = all[wallpaperPath] ?? {}
+    const manualOverrides = { ...existing }
+    delete manualOverrides.autoErrors
+
     all[wallpaperPath] = {
-      ...existing,
+      ...manualOverrides,
       compatibility: status,
       lastTested: Date.now(),
     }

--- a/src/shared/constants/compatibility.ts
+++ b/src/shared/constants/compatibility.ts
@@ -1,10 +1,10 @@
 // Wallpaper compatibility status
 export const COMPATIBILITY_OPTIONS = [
-  { label: 'Perfect', value: 'perfect', color: 'green', textColor: 'text-green-500', bgColor: 'bg-green-500' },
-  { label: 'Minor Issues', value: 'minor', color: 'yellow', textColor: 'text-yellow-500', bgColor: 'bg-yellow-500' },
-  { label: 'Major Issues', value: 'major', color: 'orange', textColor: 'text-orange-500', bgColor: 'bg-orange-500' },
-  { label: 'Broken', value: 'broken', color: 'red', textColor: 'text-red-500', bgColor: 'bg-red-500' },
-  { label: 'Unknown', value: 'unknown', color: 'gray', textColor: 'text-muted-foreground', bgColor: 'bg-muted-foreground/50' },
+  { label: 'Perfect', value: 'perfect', severity: 1, color: 'green', textColor: 'text-green-500', bgColor: 'bg-green-500' },
+  { label: 'Minor Issues', value: 'minor', severity: 2, color: 'yellow', textColor: 'text-yellow-500', bgColor: 'bg-yellow-500' },
+  { label: 'Major Issues', value: 'major', severity: 3, color: 'orange', textColor: 'text-orange-500', bgColor: 'bg-orange-500' },
+  { label: 'Broken', value: 'broken', severity: 4, color: 'red', textColor: 'text-red-500', bgColor: 'bg-red-500' },
+  { label: 'Unknown', value: 'unknown', severity: 0, color: 'gray', textColor: 'text-muted-foreground', bgColor: 'bg-muted-foreground/50' },
 ] as const
 export type CompatibilityStatus = typeof COMPATIBILITY_OPTIONS[number]['value']
 
@@ -12,6 +12,10 @@ export type CompatibilityStatus = typeof COMPATIBILITY_OPTIONS[number]['value']
 export const COMPATIBILITY_CONFIG = Object.fromEntries(
   COMPATIBILITY_OPTIONS.map(opt => [opt.value, opt])
 ) as Record<CompatibilityStatus, typeof COMPATIBILITY_OPTIONS[number]>
+
+export const COMPATIBILITY_SEVERITY = Object.fromEntries(
+  COMPATIBILITY_OPTIONS.map(opt => [opt.value, opt.severity])
+) as Record<CompatibilityStatus, typeof COMPATIBILITY_OPTIONS[number]['severity']>
 
 // Compatibility scan progress
 export interface ScanProgress {


### PR DESCRIPTION
- Added severity levels (0-4) to compatibility options for ranking issue severity
- Changed auto-compatibility to only update if new status is more severe than existing
- Removed silence timer logic; now classify on process exit regardless of stderr timing
- Clear autoErrors when user manually sets compatibility status
- Skip classification if process exits due to signal