### PR TITLE
Resolve Steam libraries for wallpaper paths

### DIFF
--- a/src/main/services/playlists/playlist.utils.ts
+++ b/src/main/services/playlists/playlist.utils.ts
@@ -1,8 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { STEAM_PATHS } from '../../../shared/constants/app'
 import type { SteamConfig } from '../../../shared/constants/playlist'
-import { expandPath } from '../wallpaper/wallpaper.utils'
+import { resolveSteamLibraryPaths } from '../wallpaper/wallpaper.utils'
 
 const DEFAULT_CONFIG: SteamConfig = {
   steamuser: {
@@ -12,9 +11,10 @@ const DEFAULT_CONFIG: SteamConfig = {
 }
 
 export async function findSteamConfigPath(): Promise<string | null> {
-  for (const basePath of STEAM_PATHS) {
-    const expanded = expandPath(basePath)
-    const configPath = path.join(expanded, 'steamapps/common/wallpaper_engine/config.json')
+  const steamLibraryPaths = await resolveSteamLibraryPaths()
+
+  for (const steamLibraryPath of steamLibraryPaths) {
+    const configPath = path.join(steamLibraryPath, 'steamapps/common/wallpaper_engine/config.json')
     try {
       await fs.access(configPath)
       return configPath
@@ -29,9 +29,10 @@ export async function ensureSteamConfigPath(): Promise<string> {
   const existing = await findSteamConfigPath()
   if (existing) return existing
 
-  for (const basePath of STEAM_PATHS) {
-    const expanded = expandPath(basePath)
-    const configDir = path.join(expanded, 'steamapps/common/wallpaper_engine')
+  const steamLibraryPaths = await resolveSteamLibraryPaths()
+
+  for (const steamLibraryPath of steamLibraryPaths) {
+    const configDir = path.join(steamLibraryPath, 'steamapps/common/wallpaper_engine')
     const configPath = path.join(configDir, 'config.json')
 
     try {

--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -6,11 +6,11 @@ import { displayService } from '../display'
 import { settingsService } from '../settings'
 import { storeService } from '../store'
 import { hostSpawn, hostExecAsync, hostCommandExists, isFlatpak } from '../../utils/host'
-import { CACHE_TTL, WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
+import { WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
 import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE, type ApplyWallpaperOptions, type Wallpaper, type WallpaperOverrides } from '../../../shared/constants/wallpaper'
 import { invalidationService } from '../invalidation'
 import { compatibilityService } from '../compatibility'
-import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry, resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir } from './wallpaper.utils'
+import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry, resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir, resolveTimedCache, type TimedCache } from './wallpaper.utils'
 import { wallpaperStateManager } from './state-manager/state-manager'
 import type { IWallpaperService } from './wallpaper.interface'
 import type { MutationResult, ActiveWallpaperEntry, ApplyTarget, OverrideMutation, ServiceAction, DebugInfo } from './wallpaper.types'
@@ -19,7 +19,7 @@ class WallpaperService implements IWallpaperService {
   private static instance: WallpaperService | null = null
 
   private wallpaperCache: Wallpaper[] | null = null
-  private cacheTimestamp: number | null = null
+  private wallpaperCacheEntry: TimedCache<Wallpaper[]> | null = null
   private overridesStore = storeService.wallpaperOverrides
   private fsWatchers: fsSync.FSWatcher[] = []
   private reapplyTimer: ReturnType<typeof setTimeout> | null = null
@@ -128,7 +128,7 @@ class WallpaperService implements IWallpaperService {
 
       case 'invalidateCache':
         this.wallpaperCache = null
-        this.cacheTimestamp = null
+        this.wallpaperCacheEntry = null
         return
 
       case 'cleanup':
@@ -144,14 +144,8 @@ class WallpaperService implements IWallpaperService {
   }
 
   private async getWallpapers(): Promise<Wallpaper[]> {
-    const now = Date.now()
-    const cacheExpired = !this.cacheTimestamp || (now - this.cacheTimestamp) > CACHE_TTL
-
-    if (!this.wallpaperCache || cacheExpired) {
-      this.wallpaperCache = await this.scanWallpapers()
-      this.cacheTimestamp = now
-    }
-
+    this.wallpaperCacheEntry = await resolveTimedCache(this.wallpaperCacheEntry, () => this.scanWallpapers())
+    this.wallpaperCache = this.wallpaperCacheEntry.value
     return this.wallpaperCache
   }
 
@@ -609,7 +603,7 @@ class WallpaperService implements IWallpaperService {
           clearTimeout(debounce)
           debounce = setTimeout(() => {
             this.wallpaperCache = null
-            this.cacheTimestamp = null
+            this.wallpaperCacheEntry = null
             invalidationService.emit('wallpaper.getWallpapers')
           }, 500)
         })

--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -6,11 +6,11 @@ import { displayService } from '../display'
 import { settingsService } from '../settings'
 import { storeService } from '../store'
 import { hostSpawn, hostExecAsync, hostCommandExists, isFlatpak } from '../../utils/host'
-import { CACHE_TTL, STEAM_PATHS, WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
+import { CACHE_TTL, WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
 import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE, type ApplyWallpaperOptions, type Wallpaper, type WallpaperOverrides } from '../../../shared/constants/wallpaper'
 import { invalidationService } from '../invalidation'
 import { compatibilityService } from '../compatibility'
-import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry } from './wallpaper.utils'
+import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry, resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir } from './wallpaper.utils'
 import { wallpaperStateManager } from './state-manager/state-manager'
 import type { IWallpaperService } from './wallpaper.interface'
 import type { MutationResult, ActiveWallpaperEntry, ApplyTarget, OverrideMutation, ServiceAction, DebugInfo } from './wallpaper.types'
@@ -160,9 +160,9 @@ class WallpaperService implements IWallpaperService {
     const wallpapers: Wallpaper[] = []
     const seen: Set<string> = new Set()
 
-    for (const basePath of STEAM_PATHS) {
-      const expanded = expandPath(basePath)
+    const steamLibraryPaths = await resolveSteamLibraryPaths()
 
+    for (const expanded of steamLibraryPaths) {
       const workshopPath = path.join(expanded, 'steamapps/workshop/content', String(WALLPAPER_ENGINE_APP_ID))
       try {
         await fs.access(workshopPath)
@@ -308,7 +308,7 @@ class WallpaperService implements IWallpaperService {
   }
 
   private async spawnWindowed(options: ApplyWallpaperOptions): Promise<MutationResult> {
-    let args = ['--bg', options.backgroundId, ...this.buildArgs(options)]
+    let args = ['--bg', options.backgroundId, ...await this.buildArgs(options)]
     // 'emit-flag' means run in app-level window mode with no backend geometry flag.
     if (options.windowed !== 'emit-flag' && options.windowed) {
       const { x, y, width, height } = options.windowed
@@ -344,7 +344,7 @@ class WallpaperService implements IWallpaperService {
       args.push('--screen-root', screen)
     }
     args.push('--bg', options.backgroundId)
-    args.push(...this.buildArgs(options))
+    args.push(...await this.buildArgs(options))
 
     try {
       // Kill orphaned processes
@@ -535,7 +535,7 @@ class WallpaperService implements IWallpaperService {
 
   // ── Private: CLI args builder ──────────────────────────────────────────
 
-  private buildArgs(options: ApplyWallpaperOptions): string[] {
+  private async buildArgs(options: ApplyWallpaperOptions): Promise<string[]> {
     const args: string[] = []
     const all = this.overridesStore.get('overrides')
     const overrides = all[options.backgroundId] ?? {}
@@ -546,6 +546,7 @@ class WallpaperService implements IWallpaperService {
     const disableMouse = overrides.disableMouse ?? options.disableMouse
     const disableParallax = overrides.disableParallax ?? options.disableParallax
     const scaling = overrides.scaling ?? options.scaling
+    const assetsDir = settingsService.getSetting('assetsDir') ?? await resolveWallpaperEngineAssetsDir()
 
     if (options.silent) {
       args.push('--silent')
@@ -560,6 +561,7 @@ class WallpaperService implements IWallpaperService {
     if (disableParallax) args.push('--disable-parallax')
     if (options.noFullscreenPause) args.push('--no-fullscreen-pause')
     if (scaling && scaling !== 'default') args.push('--scaling', scaling)
+    if (assetsDir) args.push('--assets-dir', assetsDir)
 
     return args
   }

--- a/src/main/services/wallpaper/wallpaper.utils.test.ts
+++ b/src/main/services/wallpaper/wallpaper.utils.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import { resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir } from './wallpaper.utils'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  access: vi.fn(),
+}))
+
+const mockReadFile = vi.mocked(fs.readFile)
+const mockAccess = vi.mocked(fs.access)
+
+describe('resolveSteamLibraryPaths', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset()
+    mockAccess.mockReset()
+  })
+
+  it('includes Steam libraries from libraryfolders.vdf', async () => {
+    mockReadFile.mockResolvedValueOnce(`
+"libraryfolders"
+{
+  "0"
+  {
+    "path" "/home/user/.local/share/Steam"
+  }
+  "1"
+  {
+    "path" "/some/other/folder/Steam"
+  }
+}
+`)
+
+    const paths = await resolveSteamLibraryPaths(['~/.local/share/Steam'])
+
+    expect(paths).toContain('/home/user/.local/share/Steam')
+    expect(paths).toContain('/some/other/folder/Steam')
+  })
+
+  it('keeps default paths when libraryfolders.vdf is missing', async () => {
+    mockReadFile.mockRejectedValueOnce(new Error('missing'))
+
+    await expect(resolveSteamLibraryPaths(['/steam'])).resolves.toEqual(['/steam'])
+  })
+})
+
+describe('resolveWallpaperEngineAssetsDir', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset()
+    mockAccess.mockReset()
+  })
+
+  it('finds Wallpaper Engine assets in a Steam library', async () => {
+    mockReadFile.mockRejectedValueOnce(new Error('missing'))
+    mockAccess.mockResolvedValueOnce(undefined)
+
+    await expect(resolveWallpaperEngineAssetsDir(['/steam'])).resolves.toBe('/steam/steamapps/common/wallpaper_engine/assets')
+  })
+
+  it('returns null when no assets folder exists', async () => {
+    mockReadFile.mockRejectedValueOnce(new Error('missing'))
+    mockAccess.mockRejectedValueOnce(new Error('missing'))
+
+    await expect(resolveWallpaperEngineAssetsDir(['/steam'])).resolves.toBeNull()
+  })
+})

--- a/src/main/services/wallpaper/wallpaper.utils.ts
+++ b/src/main/services/wallpaper/wallpaper.utils.ts
@@ -12,6 +12,13 @@ const IMAGE_HEADERS_IDENTIFIERS = {
 };
 const MAX_BYTES = 8192;
 const WINDOW_SIZE_PATTERN = /^(\d+)x(\d+)$/
+const STEAM_ROOT_PATHS = [
+  '~/.local/share/Steam',
+  '~/.steam/steam',
+  '~/.var/app/com.valvesoftware.Steam/.local/share/Steam',
+  '~/.var/app/com.valvesoftware.Steam/.data/Steam',
+  '~/.var/app/com.valvesoftware.Steam/.steam/steam',
+]
 
 export const parseWindowGeometry = (size: string | null | undefined): ApplyWallpaperOptions['windowed'] => {
   const match = size?.trim().match(WINDOW_SIZE_PATTERN)
@@ -100,6 +107,40 @@ export function expandPath(p: string): string {
     return path.join(process.env.HOME ?? '', p.slice(1))
   }
   return p
+}
+
+export async function resolveSteamLibraryPaths(basePaths = STEAM_ROOT_PATHS): Promise<string[]> {
+  const libraries = new Set<string>()
+
+  for (const basePath of basePaths) {
+    const expanded = expandPath(basePath)
+    libraries.add(expanded)
+
+    const libraryFoldersPath = path.join(expanded, 'steamapps/libraryfolders.vdf')
+    try {
+      const data = await fs.readFile(libraryFoldersPath, 'utf-8')
+      const matches = data.matchAll(/"path"\s+"([^"]+)"/g)
+      for (const match of matches) {
+        libraries.add(match[1].replace(/\\\\/g, '\\'))
+      }
+    } catch { /* path may not be a Steam root */ }
+  }
+
+  return [...libraries]
+}
+
+export async function resolveWallpaperEngineAssetsDir(basePaths?: string[]): Promise<string | null> {
+  const steamLibraryPaths = await resolveSteamLibraryPaths(basePaths)
+
+  for (const steamLibraryPath of steamLibraryPaths) {
+    const assetsDir = path.join(steamLibraryPath, 'steamapps/common/wallpaper_engine/assets')
+    try {
+      await fs.access(assetsDir)
+      return assetsDir
+    } catch { /* path doesn't exist */ }
+  }
+
+  return null
 }
 
 export function parseWallpaperType(rawType?: string): WallpaperType {

--- a/src/main/services/wallpaper/wallpaper.utils.ts
+++ b/src/main/services/wallpaper/wallpaper.utils.ts
@@ -1,9 +1,15 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
+import { CACHE_TTL, STEAM_ROOT_PATHS } from '../../../shared/constants/app'
 import type { ApplyWallpaperOptions, WallpaperType } from '../../../shared/constants/wallpaper'
 import { hostExecAsync } from '../../utils/host'
 
 type ImageType = "jpeg" | "png" | "bmp"
+export type TimedCache<T> = {
+  value: T
+  timestamp: number
+  key?: string
+}
 
 const IMAGE_HEADERS_IDENTIFIERS = {
   jpeg: 0xffd8,
@@ -12,13 +18,23 @@ const IMAGE_HEADERS_IDENTIFIERS = {
 };
 const MAX_BYTES = 8192;
 const WINDOW_SIZE_PATTERN = /^(\d+)x(\d+)$/
-const STEAM_ROOT_PATHS = [
-  '~/.local/share/Steam',
-  '~/.steam/steam',
-  '~/.var/app/com.valvesoftware.Steam/.local/share/Steam',
-  '~/.var/app/com.valvesoftware.Steam/.data/Steam',
-  '~/.var/app/com.valvesoftware.Steam/.steam/steam',
-]
+let steamLibraryPathsCache: TimedCache<string[]> | null = null
+
+export async function resolveTimedCache<T>(
+  cache: TimedCache<T> | null,
+  load: () => Promise<T>,
+  key?: string,
+): Promise<TimedCache<T>> {
+  if (cache && (!key || cache.key === key) && (Date.now() - cache.timestamp) <= CACHE_TTL) {
+    return cache
+  }
+
+  return {
+    value: await load(),
+    timestamp: Date.now(),
+    key,
+  }
+}
 
 export const parseWindowGeometry = (size: string | null | undefined): ApplyWallpaperOptions['windowed'] => {
   const match = size?.trim().match(WINDOW_SIZE_PATTERN)
@@ -110,23 +126,27 @@ export function expandPath(p: string): string {
 }
 
 export async function resolveSteamLibraryPaths(basePaths = STEAM_ROOT_PATHS): Promise<string[]> {
-  const libraries = new Set<string>()
+  steamLibraryPathsCache = await resolveTimedCache(steamLibraryPathsCache, async () => {
+    const libraries = new Set<string>()
 
-  for (const basePath of basePaths) {
-    const expanded = expandPath(basePath)
-    libraries.add(expanded)
+    for (const basePath of basePaths) {
+      const expanded = expandPath(basePath)
+      libraries.add(expanded)
 
-    const libraryFoldersPath = path.join(expanded, 'steamapps/libraryfolders.vdf')
-    try {
-      const data = await fs.readFile(libraryFoldersPath, 'utf-8')
-      const matches = data.matchAll(/"path"\s+"([^"]+)"/g)
-      for (const match of matches) {
-        libraries.add(match[1].replace(/\\\\/g, '\\'))
-      }
-    } catch { /* path may not be a Steam root */ }
-  }
+      const libraryFoldersPath = path.join(expanded, 'steamapps/libraryfolders.vdf')
+      try {
+        const data = await fs.readFile(libraryFoldersPath, 'utf-8')
+        const matches = data.matchAll(/"path"\s+"([^"]+)"/g)
+        for (const match of matches) {
+          libraries.add(match[1].replace(/\\\\/g, '\\'))
+        }
+      } catch { /* path may not be a Steam root */ }
+    }
 
-  return [...libraries]
+    return [...libraries]
+  }, basePaths.join('\0'))
+
+  return steamLibraryPathsCache.value
 }
 
 export async function resolveWallpaperEngineAssetsDir(basePaths?: string[]): Promise<string | null> {

--- a/src/main/trpc/routes/playlist.ts
+++ b/src/main/trpc/routes/playlist.ts
@@ -5,6 +5,7 @@ import { wallpaperService } from '../../services/wallpaper/wallpaper'
 import { settingsService } from '../../services/settings'
 import { displayService } from '../../services/display'
 import { hostCommandExists, hostSpawn } from '../../utils/host'
+import { resolveWallpaperEngineAssetsDir } from '../../services/wallpaper/wallpaper.utils'
 import { PLAYLIST_TIME_UNIT_VALUES, PLAYLIST_ORDER_VALUES, PLAYLIST_MODE_VALUES } from '../../../shared/constants/playlist'
 import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE } from '../../../shared/constants/wallpaper'
 
@@ -110,12 +111,16 @@ export const playlistRouter = trpc.router({
       // Build command args for playlist mode with user settings
       const settings = await settingsService.loadSettings()
       const settingsArgs = settingsService.settingsToArgs(settings)
+      const assetsDir = settings.assetsDir ?? await resolveWallpaperEngineAssetsDir()
       const args: string[] = []
       if (targetScreen && !settings.windowMode) {
         args.push('--screen-root', targetScreen)
       }
       args.push('--playlist', input.playlistName)
       args.push(...settingsArgs)
+      if (!settings.assetsDir && assetsDir) {
+        args.push('--assets-dir', assetsDir)
+      }
 
       try {
         const debugMode = settingsService.getSetting('debugMode')

--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -124,13 +124,4 @@ export const APP_NAME = 'Linux Wallpaper Engine'
 export const APP_VERSION = packageJson.version
 export const WALLPAPER_ENGINE_APP_ID = 431960
 
-// Steam paths to search for wallpapers
-export const STEAM_PATHS = [
-  '~/.local/share/Steam',
-  '~/.steam/steam',
-  '~/.var/app/com.valvesoftware.Steam/.local/share/Steam',
-  '~/.var/app/com.valvesoftware.Steam/.data/Steam',
-  '~/.var/app/com.valvesoftware.Steam/.steam/steam',
-]
-
 export const CACHE_TTL = 5 * 60 * 1000 // 5 minutes

--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -125,3 +125,11 @@ export const APP_VERSION = packageJson.version
 export const WALLPAPER_ENGINE_APP_ID = 431960
 
 export const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+export const STEAM_ROOT_PATHS = [
+  '~/.local/share/Steam',
+  '~/.steam/steam',
+  '~/.var/app/com.valvesoftware.Steam/.local/share/Steam',
+  '~/.var/app/com.valvesoftware.Steam/.data/Steam',
+  '~/.var/app/com.valvesoftware.Steam/.steam/steam',
+]


### PR DESCRIPTION
## Summary

I have two Steam libraries, and the second one is where I add all the games. Currently the app assumes the first/default Steam library is the one it should use, and because of this it fails in several places:

- Installed Wallpaper Engine wallpapers do not show up.
- Scanning installed wallpapers returns empty.
- After installing a wallpaper through the app, it shows on the search UI as installed, but when you refresh the page it asks to install again. If you try installing and then enable it, it fails.
- Playlist config lookup can miss the real Wallpaper Engine install.
- Launching wallpapers can fail because `linux-wallpaperengine` cannot find the Wallpaper Engine `assets` directory.
- Other smaller UI failures

This PR centralizes Steam library discovery by reading Steam’s `libraryfolders.vdf`. This is the Steam-managed file that records all configured Steam library folders, including secondary libraries outside the default install path. By using it, the app can find Wallpaper Engine files even when Wallpaper Engine and its Workshop content live in another Steam library.

The resolved Steam libraries are then used everywhere we need Wallpaper Engine files.

## Changes

- Added `resolveSteamLibraryPaths()` to discover all Steam libraries from known Steam roots.
- Added `resolveWallpaperEngineAssetsDir()` to auto-detect `steamapps/common/wallpaper_engine/assets`.
- Updated installed wallpaper scanning to search all resolved Steam libraries.
- Updated playlist config lookup/creation to search all resolved Steam libraries.
- Updated wallpaper and playlist launches to pass `--assets-dir` automatically when the user has not configured `assetsDir` (which I assume is currently an internal-only config, since I couldn't find it on the UI).
- Removed the shared `STEAM_PATHS` export; Steam root paths are now an implementation detail of the resolver.
- Added unit coverage for Steam library and Wallpaper Engine assets discovery.

## Verification

- `bun run typecheck`
- `bun run test src/main/services/wallpaper/wallpaper.utils.test.ts`
- Manually verified installed wallpapers show up from a secondary Steam library.
- Manually verified wallpaper launch no longer fails due to missing assets.

Comparison between the current version (left), and this PR (right)

https://github.com/user-attachments/assets/3cfeffc4-4335-4a1c-8b3a-677b4b5fd160

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->