### PR TITLE
fix: virtualize wallpaper grid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@tanstack/react-form": "^1.28.3",
         "@tanstack/react-query": "^5.90.17",
         "@tanstack/react-router": "^1.147.2",
+        "@tanstack/react-virtual": "^3.14.2",
         "@trpc/client": "^11.8.1",
         "@trpc/react-query": "^11.8.1",
         "@trpc/server": "^11.8.1",
@@ -618,6 +619,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.8.1", "", { "dependencies": { "@tanstack/store": "0.8.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XItJt+rG8c5Wn/2L/bnxys85rBpm0BfMbhb4zmPVLXAKY9POrp1xd6IbU4PKoOI+jSEGc3vntPRfLGSgXfE2Ig=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.2", "", { "dependencies": { "@tanstack/virtual-core": "3.17.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.147.1", "", { "dependencies": { "@tanstack/history": "1.145.7", "@tanstack/store": "^0.8.0", "cookie-es": "^2.0.0", "seroval": "^1.4.1", "seroval-plugins": "^1.4.0", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-yf8o3CNgJVGO5JnIqiTe0y2eChxEM0w7TrEs1VSumL/zz2bQroYGNr1mOXJ2VeN+7YfJJwjEqq71P5CzWwMzRg=="],
 
     "@tanstack/router-generator": ["@tanstack/router-generator@1.147.1", "", { "dependencies": { "@tanstack/router-core": "1.147.1", "@tanstack/router-utils": "1.143.11", "@tanstack/virtual-file-routes": "1.145.4", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-4Ypzmfuldl1RF6LP6SWyBQMVQM0/xDtHLsKGKl1+xX6aqQCNt2qBZP2gz3epcDI+JxJzyLYYfmvzQtEh4pUHng=="],
@@ -627,6 +630,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.143.11", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "ansis": "^4.1.0", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-N24G4LpfyK8dOlnP8BvNdkuxg1xQljkyl6PcrdiPSA301pOjatRT1y8wuCCJZKVVD8gkd0MpCZ0VEjRMGILOtA=="],
 
     "@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.0", "", {}, "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.145.4", "", {}, "sha512-CI75JrfqSluhdGwLssgVeQBaCphgfkMQpi8MCY3UJX1hoGzXa8kHYJcUuIFMOLs1q7zqHy++EVVtMK03osR5wQ=="],
 

--- a/distro/nix/bun.nix
+++ b/distro/nix/bun.nix
@@ -1249,6 +1249,10 @@
     url = "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.8.1.tgz";
     hash = "sha512-XItJt+rG8c5Wn/2L/bnxys85rBpm0BfMbhb4zmPVLXAKY9POrp1xd6IbU4PKoOI+jSEGc3vntPRfLGSgXfE2Ig==";
   };
+  "@tanstack/react-virtual@3.14.2" = fetchurl {
+    url = "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz";
+    hash = "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==";
+  };
   "@tanstack/router-core@1.147.1" = fetchurl {
     url = "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.147.1.tgz";
     hash = "sha512-yf8o3CNgJVGO5JnIqiTe0y2eChxEM0w7TrEs1VSumL/zz2bQroYGNr1mOXJ2VeN+7YfJJwjEqq71P5CzWwMzRg==";
@@ -1272,6 +1276,10 @@
   "@tanstack/store@0.8.1" = fetchurl {
     url = "https://registry.npmjs.org/@tanstack/store/-/store-0.8.1.tgz";
     hash = "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw==";
+  };
+  "@tanstack/virtual-core@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz";
+    hash = "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==";
   };
   "@tanstack/virtual-file-routes@1.145.4" = fetchurl {
     url = "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.145.4.tgz";

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@tanstack/react-form": "^1.28.3",
     "@tanstack/react-query": "^5.90.17",
     "@tanstack/react-router": "^1.147.2",
+    "@tanstack/react-virtual": "^3.13.0",
     "@trpc/client": "^11.8.1",
     "@trpc/react-query": "^11.8.1",
     "@trpc/server": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@tanstack/react-form": "^1.28.3",
     "@tanstack/react-query": "^5.90.17",
     "@tanstack/react-router": "^1.147.2",
-    "@tanstack/react-virtual": "^3.13.0",
+    "@tanstack/react-virtual": "^3.14.2",
     "@trpc/client": "^11.8.1",
     "@trpc/react-query": "^11.8.1",
     "@trpc/server": "^11.8.1",

--- a/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { FolderOpen, type LucideIcon } from "lucide-react"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { Skeleton } from "@/components/ui/skeleton"
+import { EmptyState } from "@/components/empty-state"
+import { WallpaperCard } from "./wallpaper-card"
+import type { Wallpaper } from "../../../shared/constants/wallpaper"
+import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
+
+const SKELETON_COUNT = 12
+const GAP = 16 // matches gap-4 (1rem)
+const MIN_CARD_WIDTH = 200 // target min card width; drives responsive column count
+const MAX_COLS = 8
+const OVERSCAN = 3
+
+interface VirtualizedWallpaperGridProps {
+    wallpapers: Wallpaper[]
+    isLoading: boolean
+    compatibilityMap?: Record<string, CompatibilityStatus>
+    showCompatibilityDot?: boolean
+    selectedId?: string
+    onCardClick: (wallpaper: Wallpaper) => void
+    emptyIcon?: LucideIcon
+    emptyMessage?: string
+    emptySubMessage?: string
+}
+
+/** Walk up the DOM to the nearest scrollable ancestor (the app-shell <main>). */
+function findScrollParent(node: HTMLElement | null): HTMLElement | null {
+    let el = node?.parentElement ?? null
+    while (el) {
+        const { overflowY } = getComputedStyle(el)
+        if (overflowY === "auto" || overflowY === "scroll") return el
+        el = el.parentElement
+    }
+    return null
+}
+
+export function VirtualizedWallpaperGrid({
+    wallpapers,
+    isLoading,
+    compatibilityMap,
+    showCompatibilityDot = true,
+    selectedId,
+    onCardClick,
+    emptyIcon: EmptyIcon = FolderOpen,
+    emptyMessage = "No wallpapers found",
+    emptySubMessage,
+}: VirtualizedWallpaperGridProps) {
+    const parentRef = useRef<HTMLDivElement>(null)
+    const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
+    const [width, setWidth] = useState(0)
+    const [scrollMargin, setScrollMargin] = useState(0)
+
+    // Resolve the scroll container once mounted.
+    useLayoutEffect(() => {
+        setScrollEl(findScrollParent(parentRef.current))
+    }, [])
+
+    // Track container width (drives column count) and the list's offset within the
+    // scroll element (scrollMargin) so rows position correctly below the banner.
+    useLayoutEffect(() => {
+        const node = parentRef.current
+        if (!node) return
+
+        const measure = () => {
+            setWidth(node.clientWidth)
+            if (scrollEl) {
+                const parentRect = node.getBoundingClientRect()
+                const scrollRect = scrollEl.getBoundingClientRect()
+                setScrollMargin(scrollEl.scrollTop + parentRect.top - scrollRect.top)
+            }
+        }
+
+        measure()
+        const observer = new ResizeObserver(measure)
+        observer.observe(node)
+        return () => observer.disconnect()
+    }, [scrollEl])
+
+    const columns = Math.min(
+        MAX_COLS,
+        Math.max(1, Math.floor((width + GAP) / (MIN_CARD_WIDTH + GAP))),
+    )
+    const cardWidth = columns > 0 ? (width - GAP * (columns - 1)) / columns : 0
+    const rowHeight = cardWidth + GAP // cards are square (aspect-square)
+    const rowCount = Math.ceil(wallpapers.length / columns)
+
+    const virtualizer = useVirtualizer({
+        count: rowCount,
+        getScrollElement: () => scrollEl,
+        estimateSize: () => rowHeight,
+        overscan: OVERSCAN,
+        scrollMargin,
+    })
+
+    // Re-measure rows when geometry changes (column count / width).
+    useEffect(() => {
+        virtualizer.measure()
+    }, [virtualizer, columns, rowHeight])
+
+    if (isLoading) {
+        return (
+            <div
+                className="grid gap-4"
+                style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, 1fr))` }}
+            >
+                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                    <Skeleton key={i} className="aspect-square rounded-xl" />
+                ))}
+            </div>
+        )
+    }
+
+    if (wallpapers.length === 0) {
+        return <EmptyState icon={EmptyIcon} title={emptyMessage} description={emptySubMessage} />
+    }
+
+    return (
+        <div ref={parentRef}>
+            <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+                {virtualizer.getVirtualItems().map((virtualRow) => {
+                    const start = virtualRow.index * columns
+                    const rowItems = wallpapers.slice(start, start + columns)
+                    return (
+                        <div
+                            key={virtualRow.key}
+                            data-index={virtualRow.index}
+                            ref={virtualizer.measureElement}
+                            className="grid gap-4"
+                            style={{
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                width: "100%",
+                                transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                                paddingBottom: GAP,
+                            }}
+                        >
+                            {rowItems.map((wallpaper) => (
+                                <WallpaperCard
+                                    key={wallpaper.id}
+                                    wallpaper={wallpaper}
+                                    selected={selectedId === wallpaper.id}
+                                    onClick={onCardClick}
+                                    compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                                    showCompatibilityDot={showCompatibilityDot}
+                                />
+                            ))}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
@@ -6,12 +6,12 @@ import { EmptyState } from "@/components/empty-state"
 import { WallpaperCard } from "./wallpaper-card"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
+import { findScrollParent } from "@/lib/utils"
 
-const SKELETON_COUNT = 12
 const GAP = 16 // matches gap-4 (1rem)
 const MIN_CARD_WIDTH = 200 // target min card width; drives responsive column count
-const MAX_COLS = 8
-const OVERSCAN = 3
+const MAX_COLS = 8 // cap columns so cards don't shrink on ultrawide displays
+const OVERSCAN = 3 // rows rendered beyond the viewport to smooth scrolling
 
 interface VirtualizedWallpaperGridProps {
     wallpapers: Wallpaper[]
@@ -25,16 +25,7 @@ interface VirtualizedWallpaperGridProps {
     emptySubMessage?: string
 }
 
-/** Walk up the DOM to the nearest scrollable ancestor (the app-shell <main>). */
-function findScrollParent(node: HTMLElement | null): HTMLElement | null {
-    let el = node?.parentElement ?? null
-    while (el) {
-        const { overflowY } = getComputedStyle(el)
-        if (overflowY === "auto" || overflowY === "scroll") return el
-        el = el.parentElement
-    }
-    return null
-}
+
 
 export function VirtualizedWallpaperGrid({
     wallpapers,
@@ -50,6 +41,7 @@ export function VirtualizedWallpaperGrid({
     const parentRef = useRef<HTMLDivElement>(null)
     const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
     const [width, setWidth] = useState(0)
+    const [viewportHeight, setViewportHeight] = useState(0)
     const [scrollMargin, setScrollMargin] = useState(0)
 
     // Resolve the scroll container once mounted.
@@ -66,6 +58,7 @@ export function VirtualizedWallpaperGrid({
         const measure = () => {
             setWidth(node.clientWidth)
             if (scrollEl) {
+                setViewportHeight(scrollEl.clientHeight)
                 const parentRect = node.getBoundingClientRect()
                 const scrollRect = scrollEl.getBoundingClientRect()
                 setScrollMargin(scrollEl.scrollTop + parentRect.top - scrollRect.top)
@@ -86,6 +79,10 @@ export function VirtualizedWallpaperGrid({
     const rowHeight = cardWidth + GAP // cards are square (aspect-square)
     const rowCount = Math.ceil(wallpapers.length / columns)
 
+    // Fill the visible viewport with skeletons rather than a fixed count.
+    const skeletonRows = rowHeight > 0 ? Math.ceil((viewportHeight || rowHeight * 3) / rowHeight) : 3
+    const skeletonCount = columns * skeletonRows
+
     const virtualizer = useVirtualizer({
         count: rowCount,
         getScrollElement: () => scrollEl,
@@ -99,59 +96,65 @@ export function VirtualizedWallpaperGrid({
         virtualizer.measure()
     }, [virtualizer, columns, rowHeight])
 
-    if (isLoading) {
-        return (
-            <div
-                className="grid gap-4"
-                style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, 1fr))` }}
-            >
-                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                    <Skeleton key={i} className="aspect-square rounded-xl" />
-                ))}
-            </div>
-        )
-    }
+    const skeleton = (
+        <div
+            className="grid gap-4"
+            style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, 1fr))` }}
+        >
+            {Array.from({ length: skeletonCount }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-xl" />
+            ))}
+        </div>
+    )
 
-    if (wallpapers.length === 0) {
-        return <EmptyState icon={EmptyIcon} title={emptyMessage} description={emptySubMessage} />
-    }
+    const rows = (
+        <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+                const start = virtualRow.index * columns
+                const rowItems = wallpapers.slice(start, start + columns)
+                return (
+                    <div
+                        key={virtualRow.key}
+                        data-index={virtualRow.index}
+                        ref={virtualizer.measureElement}
+                        className="grid gap-4"
+                        style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                            gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                            paddingBottom: GAP,
+                        }}
+                    >
+                        {rowItems.map((wallpaper) => (
+                            <WallpaperCard
+                                key={wallpaper.id}
+                                wallpaper={wallpaper}
+                                selected={selectedId === wallpaper.id}
+                                onClick={onCardClick}
+                                compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                                showCompatibilityDot={showCompatibilityDot}
+                            />
+                        ))}
+                    </div>
+                )
+            })}
+        </div>
+    )
 
+    // The parentRef div is now always mounted so the layout effects above can
+    // resolve the scroll parent and attach the ResizeObserver on first mount.
     return (
         <div ref={parentRef}>
-            <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
-                {virtualizer.getVirtualItems().map((virtualRow) => {
-                    const start = virtualRow.index * columns
-                    const rowItems = wallpapers.slice(start, start + columns)
-                    return (
-                        <div
-                            key={virtualRow.key}
-                            data-index={virtualRow.index}
-                            ref={virtualizer.measureElement}
-                            className="grid gap-4"
-                            style={{
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
-                                width: "100%",
-                                transform: `translateY(${virtualRow.start - scrollMargin}px)`,
-                                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                                paddingBottom: GAP,
-                            }}
-                        >
-                            {rowItems.map((wallpaper) => (
-                                <WallpaperCard
-                                    key={wallpaper.id}
-                                    wallpaper={wallpaper}
-                                    selected={selectedId === wallpaper.id}
-                                    onClick={onCardClick}
-                                    compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
-                                    showCompatibilityDot={showCompatibilityDot}
-                                />
-                            ))}
-                        </div>
-                    )
-                })}
-            </div>
+            {isLoading ? (
+                skeleton
+            ) : wallpapers.length === 0 ? (
+                <EmptyState icon={EmptyIcon} title={emptyMessage} description={emptySubMessage} />
+            ) : (
+                rows
+            )}
         </div>
     )
 }

--- a/src/renderer/components/wallpaper/wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid.tsx
@@ -1,14 +1,14 @@
 import { motion, AnimatePresence } from "framer-motion"
 import { type Wallpaper } from "./wallpaper-card"
 import { GridHeader } from "./wallpaper-grid-header"
-import { WallpaperGridLayout } from "./wallpaper-grid-layout"
+import { VirtualizedWallpaperGrid } from "./virtualized-wallpaper-grid"
 import { AlertCircle, FolderOpen } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWallpaperSearch } from "@/contexts/wallpaper-search-context"
 import { useWallpaperBackground } from "@/contexts/wallpaper-background-context"
 import { useWallpapers, filterAndSortWallpapers } from "@/hooks/use-wallpapers"
 import { useWallpaperSelection } from "@/hooks/use-wallpaper-selection"
-import { useState, useMemo, useEffect, lazy, Suspense } from "react"
+import { useMemo, useEffect, lazy, Suspense } from "react"
 import { useAtomValue } from "jotai"
 import { unsubscribedWorkshopIdsAtom } from "@/contexts/atoms/workshop-atoms"
 
@@ -17,7 +17,6 @@ const WallpaperDetails = lazy(() => import("./details-card/wallpaper-details").t
 // TODO: Fix wallpaper details size so that is consistent width with a column
 export function WallpaperGrid() {
     const { selectedWallpaper, setSelectedWallpaper, toggleWallpaper } = useWallpaperSelection()
-    const [detailsVisible, setDetailsVisible] = useState(false)
     const unsubscribedWorkshopIds = useAtomValue(unsubscribedWorkshopIdsAtom)
     const { searchQuery, filterType, filterAgeRating, filterTags, filterResolution, sortBy, sortOrder, setAvailableTags, setAvailableResolutions, filterCompatibility } = useWallpaperSearch()
     const { setSelectedUrl } = useWallpaperBackground()
@@ -119,24 +118,19 @@ export function WallpaperGrid() {
         )
     }
 
-    const gridCols = detailsVisible
-        ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
-        : "grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
-
     return (
         <div className="flex flex-col h-full">
             <GridHeader onRefresh={handleRefresh} isLoading={isFetching} />
 
             <div className="flex items-start gap-6 flex-1">
                 <div className="flex-1 h-fit transition-all duration-300">
-                    <WallpaperGridLayout
+                    <VirtualizedWallpaperGrid
                         wallpapers={wallpapers}
                         isLoading={isLoading}
                         compatibilityMap={compatibilityMap}
                         showCompatibilityDot={appSettings?.showCompatibilityDot ?? true}
                         selectedId={selectedWallpaper?.id}
                         onCardClick={toggleWallpaper}
-                        gridClassName={gridCols}
                         emptyIcon={FolderOpen}
                         emptyMessage="No wallpapers found"
                         emptySubMessage={
@@ -147,7 +141,7 @@ export function WallpaperGrid() {
                     />
                 </div>
 
-                <AnimatePresence mode="wait" onExitComplete={() => setDetailsVisible(false)}>
+                <AnimatePresence mode="wait">
                     {selectedWallpaper && (
                         <motion.div
                             key={selectedWallpaper.id}
@@ -156,7 +150,6 @@ export function WallpaperGrid() {
                             animate={{ opacity: 1, x: 0 }}
                             exit={{ opacity: 0, x: -40 }}
                             transition={{ duration: 0.3, ease: "easeOut" }}
-                            onAnimationStart={() => setDetailsVisible(true)}
                         >
                             <Suspense fallback={<Skeleton className="w-80 h-96 rounded-xl" />}>
                                 <WallpaperDetails

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -84,3 +84,14 @@ export function toWallpaper(item: WorkshopItem): Wallpaper {
     path: "",
   }
 }
+
+/** Walk up the DOM to the nearest scrollable ancestor (the app-shell <main>). */
+export function findScrollParent(node: HTMLElement | null): HTMLElement | null {
+    let el = node?.parentElement ?? null
+    while (el) {
+        const { overflowY } = getComputedStyle(el)
+        if (overflowY === "auto" || overflowY === "scroll") return el
+        el = el.parentElement
+    }
+    return null
+}


### PR DESCRIPTION
## Summary
- Replace the wallpaper grid layout with a virtualized grid
- Render wallpaper cards by visible rows to improve performance with large libraries
- Add @tanstack/react-virtual for row virtualization

## Testing
- Not run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->