### PR TITLE
Add scroll to playlist view (#75)

### DIFF
--- a/src/renderer/components/playlist/playlist-row.tsx
+++ b/src/renderer/components/playlist/playlist-row.tsx
@@ -1,5 +1,5 @@
 import { Clock, Shuffle, MoreVertical, Pencil, Trash2, Images, CircleCheck } from "lucide-react"
-import * as React from "react"
+import { useState, useEffect } from "react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { EmptyState } from "@/components/empty-state"
@@ -48,9 +48,9 @@ export function PlaylistRow({
         .filter(Boolean) as Wallpaper[]
 
     // Translate vertical wheel/trackpad scroll into horizontal carousel movement
-    const [carouselApi, setCarouselApi] = React.useState<CarouselApi>()
+    const [carouselApi, setCarouselApi] = useState<CarouselApi>()
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!carouselApi) return
         const root = carouselApi.rootNode()
         const onWheel = (event: WheelEvent) => {

--- a/src/renderer/components/playlist/playlist-row.tsx
+++ b/src/renderer/components/playlist/playlist-row.tsx
@@ -15,6 +15,7 @@ import {
     CarouselContent,
     CarouselItem,
     CarouselButtons,
+    type CarouselApi,
 } from "@/components/ui/carousel"
 import type { Playlist } from "../../../shared/constants/playlist"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
@@ -46,11 +47,30 @@ export function PlaylistRow({
         .map(path => wallpapers.find(w => w.path === path))
         .filter(Boolean) as Wallpaper[]
 
+    // Translate vertical wheel/trackpad scroll into horizontal carousel movement
+    const [carouselApi, setCarouselApi] = React.useState<CarouselApi>()
+
+    React.useEffect(() => {
+        if (!carouselApi) return
+        const root = carouselApi.rootNode()
+        const onWheel = (event: WheelEvent) => {
+            const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY
+            if (delta === 0) return
+            const forward = delta > 0
+            if (forward ? carouselApi.canScrollNext() : carouselApi.canScrollPrev()) {
+                event.preventDefault()
+                if (forward) carouselApi.scrollNext()
+                else carouselApi.scrollPrev()
+            }
+        }
+        root.addEventListener("wheel", onWheel, { passive: false })
+        return () => root.removeEventListener("wheel", onWheel)
+    }, [carouselApi])
+
     return (
         <div
-            onDoubleClick={onEdit}
             className={cn(
-                "group glass p-1 rounded-xl min-h-[200px] transition-all overflow-hidden cursor-pointer select-none"
+                "group glass p-1 rounded-xl min-h-[200px] transition-all overflow-hidden select-none"
             )}
         >
             {/* Header with info */}
@@ -116,6 +136,7 @@ export function PlaylistRow({
                         loop: false,
                         dragFree: true,
                     }}
+                    setApi={setCarouselApi}
                     className="w-full h-full"
                 >
                     <CarouselContent className="p-3 -ml-3 gap-3">


### PR DESCRIPTION
## Summary
Closes #75.

- **Horizontal wheel/trackpad scroll** on each playlist row's wallpaper carousel — vertical/horizontal wheel delta is translated into carousel movement via the embla API (no new dependency). Only intercepts when there is room to scroll, so the page still scrolls past the ends.
- **Removed double-click-to-edit** on the row to prevent accidental edits. Editing remains available from the row's ⋯ actions menu.

## Implementation
Single file: `src/renderer/components/playlist/playlist-row.tsx`
- Exposes the carousel's embla API via the existing `setApi` prop.
- Attaches a non-passive `wheel` listener on the carousel root that calls `scrollNext`/`scrollPrev` based on wheel delta.
- Drops `onDoubleClick={onEdit}` and the `cursor-pointer` class.

## How to test
- Run the app, open the Playlists page.
- Hover a row and scroll the mouse wheel / two-finger trackpad → wallpaper strip moves left/right.
- Drag and arrow buttons still work.
- Double-clicking a row no longer opens the editor; Edit still works via the ⋯ menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->