### PR TITLE
fix: randomize playlist start item

### DIFF
--- a/src/main/services/playlists/playlist.ts
+++ b/src/main/services/playlists/playlist.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises'
 import type { Playlist } from '../../../shared/constants/playlist'
 import { storeService, type ActivePlaylistInfo } from '../store'
 import { invalidationService } from '../invalidation'
-import { findSteamConfigPath, ensureSteamConfigPath, readSteamConfig, writeSteamConfig } from './playlist.utils'
+import { findSteamConfigPath, ensureSteamConfigPath, readSteamConfig, writeSteamConfig, shuffleItemsForRandomStart } from './playlist.utils'
 
 class PlaylistService {
   private static instance: PlaylistService | null = null
@@ -147,19 +147,20 @@ class PlaylistService {
     }
   }
 
-  /** Lightweight timestamp update — skips item-path validation so it can't silently fail. */
-  async stampLastApplied(name: string): Promise<void> {
-    try {
-      const configPath = await this.getConfigPath()
-      const config = await readSteamConfig(configPath)
-      const playlist = config.steamuser?.general?.playlists?.find(p => p.name === name)
-      if (!playlist) return
+  async preparePlaylistForStart(name: string): Promise<Playlist | null> {
+    const configPath = await this.getConfigPath()
+    const config = await readSteamConfig(configPath)
+    const playlist = config.steamuser?.general?.playlists?.find(p => p.name === name)
+    if (!playlist) return null
 
-      playlist.lastAppliedAt = Date.now()
-      await writeSteamConfig(configPath, config)
-    } catch {
-      // Best-effort — don't block the apply flow
+    playlist.lastAppliedAt = Date.now()
+
+    if (playlist.settings.order === 'random' && playlist.items.length > 1) {
+      playlist.items = shuffleItemsForRandomStart(playlist.items)
     }
+
+    await writeSteamConfig(configPath, config)
+    return playlist
   }
 
   // ── Active playlist state ──────────────────────────────────────────────

--- a/src/main/services/playlists/playlist.ts
+++ b/src/main/services/playlists/playlist.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises'
 import type { Playlist } from '../../../shared/constants/playlist'
 import { storeService, type ActivePlaylistInfo } from '../store'
 import { invalidationService } from '../invalidation'
-import { findSteamConfigPath, ensureSteamConfigPath, readSteamConfig, writeSteamConfig, shuffleItemsForRandomStart } from './playlist.utils'
+import { findSteamConfigPath, ensureSteamConfigPath, readSteamConfig, writeSteamConfig, experimentalRandomizeStartItem } from './playlist.utils'
 
 class PlaylistService {
   private static instance: PlaylistService | null = null
@@ -147,20 +147,20 @@ class PlaylistService {
     }
   }
 
-  async preparePlaylistForStart(name: string): Promise<Playlist | null> {
-    const configPath = await this.getConfigPath()
-    const config = await readSteamConfig(configPath)
-    const playlist = config.steamuser?.general?.playlists?.find(p => p.name === name)
-    if (!playlist) return null
+  /** Lightweight timestamp update — skips item-path validation so it can't silently fail. */
+  async stampLastApplied(name: string): Promise<void> {
+    try {
+      const configPath = await this.getConfigPath()
+      const config = await readSteamConfig(configPath)
+      const playlist = config.steamuser?.general?.playlists?.find(p => p.name === name)
+      if (!playlist) return
 
-    playlist.lastAppliedAt = Date.now()
-
-    if (playlist.settings.order === 'random' && playlist.items.length > 1) {
-      playlist.items = shuffleItemsForRandomStart(playlist.items)
+      playlist.items = experimentalRandomizeStartItem(playlist.items, playlist.settings.order)
+      playlist.lastAppliedAt = Date.now()
+      await writeSteamConfig(configPath, config)
+    } catch {
+      // Best-effort — don't block the apply flow
     }
-
-    await writeSteamConfig(configPath, config)
-    return playlist
   }
 
   // ── Active playlist state ──────────────────────────────────────────────

--- a/src/main/services/playlists/playlist.utils.test.ts
+++ b/src/main/services/playlists/playlist.utils.test.ts
@@ -1,19 +1,28 @@
 import { describe, expect, it } from 'vitest'
-import { shuffleItemsForRandomStart } from './playlist.utils'
+import { experimentalRandomizeStartItem } from './playlist.utils'
 
-describe('shuffleItemsForRandomStart', () => {
-  it('keeps a single item unchanged', () => {
-    expect(shuffleItemsForRandomStart(['one'], () => 0)).toEqual(['one'])
+describe('experimentalRandomizeStartItem', () => {
+  it('leaves non-random playlists untouched', () => {
+    const items = ['a', 'b', 'c']
+    const result = experimentalRandomizeStartItem(items, 'sequential')
+    expect(result).toBe(items)
   })
 
-  it('produces a deterministic permutation for given random indexes without mutating the input', () => {
+  it('leaves single-item random playlists untouched', () => {
+    const items = ['only']
+    const result = experimentalRandomizeStartItem(items, 'random')
+    expect(result).toBe(items)
+  })
+
+  it('shuffles random playlists without mutating the input', () => {
     const items = ['first', 'second', 'third']
     const randomIndexes = [0, 1]
 
-    const result = shuffleItemsForRandomStart(items, () => randomIndexes.shift() ?? 0)
+    const result = experimentalRandomizeStartItem(items, 'random', () => randomIndexes.shift() ?? 0)
 
     expect(result).toEqual(['third', 'second', 'first'])
     expect(items).toEqual(['first', 'second', 'third'])
+    expect(result).not.toBe(items)
   })
 
   it('gives every item a chance at the front, including the original first', () => {
@@ -21,7 +30,7 @@ describe('shuffleItemsForRandomStart', () => {
     const firstCounts = new Map<string, number>()
 
     for (let i = 0; i < 20000; i++) {
-      const first = shuffleItemsForRandomStart(items)[0]
+      const first = experimentalRandomizeStartItem(items, 'random')[0]
       firstCounts.set(first, (firstCounts.get(first) ?? 0) + 1)
     }
 

--- a/src/main/services/playlists/playlist.utils.test.ts
+++ b/src/main/services/playlists/playlist.utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { shuffleItemsForRandomStart } from './playlist.utils'
+
+describe('shuffleItemsForRandomStart', () => {
+  it('keeps a single item unchanged', () => {
+    expect(shuffleItemsForRandomStart(['one'], () => 0)).toEqual(['one'])
+  })
+
+  it('moves a non-leading item to the front when the shuffle leaves the first item first', () => {
+    const items = ['first', 'second', 'third']
+    const randomIndexes = [0, 0, 1]
+
+    const result = shuffleItemsForRandomStart(items, () => randomIndexes.shift() ?? 0)
+
+    expect(result[0]).toBe('second')
+    expect(result).toEqual(expect.arrayContaining(items))
+    expect(items).toEqual(['first', 'second', 'third'])
+  })
+
+  it('returns a shuffled copy when the first item already changes', () => {
+    const items = ['first', 'second', 'third']
+    const randomIndexes = [0, 1]
+
+    const result = shuffleItemsForRandomStart(items, () => randomIndexes.shift() ?? 0)
+
+    expect(result).toEqual(['third', 'second', 'first'])
+    expect(items).toEqual(['first', 'second', 'third'])
+  })
+})

--- a/src/main/services/playlists/playlist.utils.test.ts
+++ b/src/main/services/playlists/playlist.utils.test.ts
@@ -6,18 +6,7 @@ describe('shuffleItemsForRandomStart', () => {
     expect(shuffleItemsForRandomStart(['one'], () => 0)).toEqual(['one'])
   })
 
-  it('moves a non-leading item to the front when the shuffle leaves the first item first', () => {
-    const items = ['first', 'second', 'third']
-    const randomIndexes = [0, 0, 1]
-
-    const result = shuffleItemsForRandomStart(items, () => randomIndexes.shift() ?? 0)
-
-    expect(result[0]).toBe('second')
-    expect(result).toEqual(expect.arrayContaining(items))
-    expect(items).toEqual(['first', 'second', 'third'])
-  })
-
-  it('returns a shuffled copy when the first item already changes', () => {
+  it('produces a deterministic permutation for given random indexes without mutating the input', () => {
     const items = ['first', 'second', 'third']
     const randomIndexes = [0, 1]
 
@@ -25,5 +14,19 @@ describe('shuffleItemsForRandomStart', () => {
 
     expect(result).toEqual(['third', 'second', 'first'])
     expect(items).toEqual(['first', 'second', 'third'])
+  })
+
+  it('gives every item a chance at the front, including the original first', () => {
+    const items = ['a', 'b', 'c', 'd', 'e']
+    const firstCounts = new Map<string, number>()
+
+    for (let i = 0; i < 20000; i++) {
+      const first = shuffleItemsForRandomStart(items)[0]
+      firstCounts.set(first, (firstCounts.get(first) ?? 0) + 1)
+    }
+
+    for (const item of items) {
+      expect(firstCounts.get(item) ?? 0).toBeGreaterThan(0)
+    }
   })
 })

--- a/src/main/services/playlists/playlist.utils.ts
+++ b/src/main/services/playlists/playlist.utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import { randomInt } from 'node:crypto'
 import type { SteamConfig } from '../../../shared/constants/playlist'
 import { resolveSteamLibraryPaths } from '../wallpaper/wallpaper.utils'
 
@@ -72,4 +73,26 @@ export async function writeSteamConfig(configPath: string, config: SteamConfig):
     // Ignore backup errors
   }
   await fs.writeFile(configPath, JSON.stringify(config, null, 2))
+}
+
+type RandomIndex = (maxExclusive: number) => number
+
+export function shuffleItemsForRandomStart<T>(items: readonly T[], getRandomIndex: RandomIndex = randomInt): T[] {
+  const shuffled = [...items]
+
+  for (let currentIndex = shuffled.length - 1; currentIndex > 0; currentIndex--) {
+    const selectedIndex = getRandomIndex(currentIndex + 1)
+    const selectedItem = shuffled[selectedIndex]
+    shuffled[selectedIndex] = shuffled[currentIndex]
+    shuffled[currentIndex] = selectedItem
+  }
+
+  if (shuffled.length > 1 && shuffled[0] === items[0]) {
+    const selectedIndex = getRandomIndex(shuffled.length - 1) + 1
+    const selectedItem = shuffled[selectedIndex]
+    shuffled[selectedIndex] = shuffled[0]
+    shuffled[0] = selectedItem
+  }
+
+  return shuffled
 }

--- a/src/main/services/playlists/playlist.utils.ts
+++ b/src/main/services/playlists/playlist.utils.ts
@@ -80,18 +80,13 @@ type RandomIndex = (maxExclusive: number) => number
 export function shuffleItemsForRandomStart<T>(items: readonly T[], getRandomIndex: RandomIndex = randomInt): T[] {
   const shuffled = [...items]
 
+  // Unbiased Fisher–Yates. Every item — including the original first one —
+  // has an equal chance of ending up at the front.
   for (let currentIndex = shuffled.length - 1; currentIndex > 0; currentIndex--) {
     const selectedIndex = getRandomIndex(currentIndex + 1)
     const selectedItem = shuffled[selectedIndex]
     shuffled[selectedIndex] = shuffled[currentIndex]
     shuffled[currentIndex] = selectedItem
-  }
-
-  if (shuffled.length > 1 && shuffled[0] === items[0]) {
-    const selectedIndex = getRandomIndex(shuffled.length - 1) + 1
-    const selectedItem = shuffled[selectedIndex]
-    shuffled[selectedIndex] = shuffled[0]
-    shuffled[0] = selectedItem
   }
 
   return shuffled

--- a/src/main/services/playlists/playlist.utils.ts
+++ b/src/main/services/playlists/playlist.utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { randomInt } from 'node:crypto'
-import type { SteamConfig } from '../../../shared/constants/playlist'
+import type { PlaylistOrder, SteamConfig } from '../../../shared/constants/playlist'
 import { resolveSteamLibraryPaths } from '../wallpaper/wallpaper.utils'
 
 const DEFAULT_CONFIG: SteamConfig = {
@@ -77,17 +77,41 @@ export async function writeSteamConfig(configPath: string, config: SteamConfig):
 
 type RandomIndex = (maxExclusive: number) => number
 
-export function shuffleItemsForRandomStart<T>(items: readonly T[], getRandomIndex: RandomIndex = randomInt): T[] {
+/** Unbiased Fisher–Yates. Every item has an equal chance of ending up first. */
+function shuffle(items: readonly string[], getRandomIndex: RandomIndex): string[] {
   const shuffled = [...items]
-
-  // Unbiased Fisher–Yates. Every item — including the original first one —
-  // has an equal chance of ending up at the front.
   for (let currentIndex = shuffled.length - 1; currentIndex > 0; currentIndex--) {
     const selectedIndex = getRandomIndex(currentIndex + 1)
     const selectedItem = shuffled[selectedIndex]
     shuffled[selectedIndex] = shuffled[currentIndex]
     shuffled[currentIndex] = selectedItem
   }
-
   return shuffled
+}
+
+/**
+ * EXPERIMENTAL — workaround for an upstream linux-wallpaperengine bug.
+ *
+ * Why this exists: when a playlist is launched with `--playlist`, the backend
+ * shuffles internally but then seeks back to `playlist.items.front()` on
+ * startup, so a "random" playlist always opens on the same (first) wallpaper.
+ * See jagrat7/linux-wallpaper-engine#81 and upstream Almamu/linux-wallpaperengine.
+ *
+ * How it works around it: for random playlists we pre-shuffle the persisted
+ * item order before the backend reads config.json, so whatever the backend
+ * forces as `items[0]` is itself random. Returns the input unchanged for
+ * non-random or single-item playlists. Pure — does not mutate `items`.
+ *
+ * CAUTION: this reorders the items the backend persists, not just the start
+ * index. It is a stopgap, not the intended design — remove it (and its single
+ * call site in playlist.ts) once upstream stops seeking to items.front().
+ */
+export function experimentalRandomizeStartItem(
+  items: string[],
+  order: PlaylistOrder,
+  getRandomIndex: RandomIndex = randomInt,
+): string[] {
+  if (order !== 'random') return items
+  if (items.length <= 1) return items
+  return shuffle(items, getRandomIndex)
 }

--- a/src/main/trpc/routes/playlist.test.ts
+++ b/src/main/trpc/routes/playlist.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS } from '../../../shared/constants/app'
+import type { Playlist } from '../../../shared/constants/playlist'
+
+const { mockPlaylistService, mockWallpaperService, mockSettingsService, mockDisplayService, mockHost, mockWallpaperUtils } = vi.hoisted(() => ({
+  mockPlaylistService: {
+    getPlaylists: vi.fn(),
+    getPlaylist: vi.fn(),
+    createPlaylist: vi.fn(),
+    updatePlaylist: vi.fn(),
+    deletePlaylist: vi.fn(),
+    preparePlaylistForStart: vi.fn(),
+    getActivePlaylist: vi.fn(),
+    setActivePlaylist: vi.fn(),
+    clearActivePlaylist: vi.fn(),
+  },
+  mockWallpaperService: {
+    stop: vi.fn(),
+    apply: vi.fn(),
+  },
+  mockSettingsService: {
+    loadSettings: vi.fn(),
+    settingsToArgs: vi.fn(),
+    getSetting: vi.fn(),
+  },
+  mockDisplayService: {
+    detectDisplays: vi.fn(),
+  },
+  mockHost: {
+    hostCommandExists: vi.fn(),
+    hostSpawn: vi.fn(),
+  },
+  mockWallpaperUtils: {
+    resolveWallpaperEngineAssetsDir: vi.fn(),
+  },
+}))
+
+vi.mock('../../services/playlists/playlist', () => ({
+  playlistService: mockPlaylistService,
+}))
+
+vi.mock('../../services/wallpaper/wallpaper', () => ({
+  wallpaperService: mockWallpaperService,
+}))
+
+vi.mock('../../services/settings', () => ({
+  settingsService: mockSettingsService,
+}))
+
+vi.mock('../../services/display', () => ({
+  displayService: mockDisplayService,
+}))
+
+vi.mock('../../utils/host', () => mockHost)
+
+vi.mock('../../services/wallpaper/wallpaper.utils', () => mockWallpaperUtils)
+
+import { trpc } from '../trpc'
+import { playlistRouter } from './playlist'
+
+const caller = trpc.createCallerFactory(playlistRouter)({ senderId: undefined })
+
+const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
+  name: 'Random Mix',
+  items: ['/wallpapers/first', '/wallpapers/second', '/wallpapers/third'],
+  settings: {
+    delay: 1,
+    timeunit: 'minutes',
+    mode: 'timer',
+    order: 'random',
+    updateonpause: false,
+    videosequence: false,
+  },
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPlaylistService.getPlaylist.mockResolvedValue(makePlaylist())
+  mockPlaylistService.preparePlaylistForStart.mockResolvedValue(makePlaylist({
+    items: ['/wallpapers/second', '/wallpapers/first', '/wallpapers/third'],
+  }))
+  mockWallpaperService.stop.mockResolvedValue({ success: true })
+  mockWallpaperService.apply.mockResolvedValue({ success: true })
+  mockSettingsService.loadSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
+  mockSettingsService.settingsToArgs.mockReturnValue([])
+  mockSettingsService.getSetting.mockReturnValue(false)
+  mockDisplayService.detectDisplays.mockResolvedValue([{ name: 'HDMI-1', primary: true }])
+  mockHost.hostCommandExists.mockResolvedValue(true)
+  mockHost.hostSpawn.mockReturnValue(new EventEmitter())
+  mockWallpaperUtils.resolveWallpaperEngineAssetsDir.mockResolvedValue('/assets')
+})
+
+describe('playlistRouter', () => {
+  describe('start', () => {
+    it('prepares the playlist before spawning linux-wallpaperengine', async () => {
+      await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
+
+      expect(mockPlaylistService.preparePlaylistForStart).toHaveBeenCalledWith('Random Mix')
+      expect(mockHost.hostSpawn).toHaveBeenCalledWith('linux-wallpaperengine', [
+        '--screen-root',
+        'HDMI-1',
+        '--playlist',
+        'Random Mix',
+        '--assets-dir',
+        '/assets',
+      ], expect.any(Object))
+    })
+
+    it('registers the prepared first wallpaper as active metadata', async () => {
+      await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
+
+      expect(mockWallpaperService.apply).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'register',
+        options: {
+          backgroundId: '/wallpapers/second',
+          screen: 'HDMI-1',
+        },
+      }))
+    })
+
+    it('does not prepare a playlist when the backend is missing', async () => {
+      mockHost.hostCommandExists.mockResolvedValue(false)
+
+      const result = await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
+
+      expect(result.success).toBe(false)
+      expect(mockPlaylistService.preparePlaylistForStart).not.toHaveBeenCalled()
+      expect(mockHost.hostSpawn).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/trpc/routes/playlist.test.ts
+++ b/src/main/trpc/routes/playlist.test.ts
@@ -10,7 +10,7 @@ const { mockPlaylistService, mockWallpaperService, mockSettingsService, mockDisp
     createPlaylist: vi.fn(),
     updatePlaylist: vi.fn(),
     deletePlaylist: vi.fn(),
-    preparePlaylistForStart: vi.fn(),
+    stampLastApplied: vi.fn(),
     getActivePlaylist: vi.fn(),
     setActivePlaylist: vi.fn(),
     clearActivePlaylist: vi.fn(),
@@ -78,9 +78,7 @@ const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
 beforeEach(() => {
   vi.clearAllMocks()
   mockPlaylistService.getPlaylist.mockResolvedValue(makePlaylist())
-  mockPlaylistService.preparePlaylistForStart.mockResolvedValue(makePlaylist({
-    items: ['/wallpapers/second', '/wallpapers/first', '/wallpapers/third'],
-  }))
+  mockPlaylistService.stampLastApplied.mockResolvedValue(undefined)
   mockWallpaperService.stop.mockResolvedValue({ success: true })
   mockWallpaperService.apply.mockResolvedValue({ success: true })
   mockSettingsService.loadSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
@@ -94,10 +92,10 @@ beforeEach(() => {
 
 describe('playlistRouter', () => {
   describe('start', () => {
-    it('prepares the playlist before spawning linux-wallpaperengine', async () => {
+    it('stamps the playlist and spawns linux-wallpaperengine', async () => {
       await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
 
-      expect(mockPlaylistService.preparePlaylistForStart).toHaveBeenCalledWith('Random Mix')
+      expect(mockPlaylistService.stampLastApplied).toHaveBeenCalledWith('Random Mix')
       expect(mockHost.hostSpawn).toHaveBeenCalledWith('linux-wallpaperengine', [
         '--screen-root',
         'HDMI-1',
@@ -108,25 +106,13 @@ describe('playlistRouter', () => {
       ], expect.any(Object))
     })
 
-    it('registers the prepared first wallpaper as active metadata', async () => {
-      await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
-
-      expect(mockWallpaperService.apply).toHaveBeenCalledWith(expect.objectContaining({
-        kind: 'register',
-        options: {
-          backgroundId: '/wallpapers/second',
-          screen: 'HDMI-1',
-        },
-      }))
-    })
-
-    it('does not prepare a playlist when the backend is missing', async () => {
+    it('does not stamp or spawn when the backend is missing', async () => {
       mockHost.hostCommandExists.mockResolvedValue(false)
 
       const result = await caller.start({ playlistName: 'Random Mix', screen: 'HDMI-1' })
 
       expect(result.success).toBe(false)
-      expect(mockPlaylistService.preparePlaylistForStart).not.toHaveBeenCalled()
+      expect(mockPlaylistService.stampLastApplied).not.toHaveBeenCalled()
       expect(mockHost.hostSpawn).not.toHaveBeenCalled()
     })
   })

--- a/src/main/trpc/routes/playlist.ts
+++ b/src/main/trpc/routes/playlist.ts
@@ -92,10 +92,8 @@ export const playlistRouter = trpc.router({
         return { success: false, error: BACKEND_NOT_INSTALLED_ERROR_MESSAGE }
       }
 
-      const preparedPlaylist = await playlistService.preparePlaylistForStart(input.playlistName)
-      if (!preparedPlaylist) {
-        return { success: false, error: 'Playlist not found' }
-      }
+      // Persist lastAppliedAt so the frontend can sort by recency
+      await playlistService.stampLastApplied(input.playlistName)
 
       // Get target screen
       let targetScreen = input.screen
@@ -140,7 +138,7 @@ export const playlistRouter = trpc.router({
           proc,
           args,
           options: {
-            backgroundId: preparedPlaylist.items[0],
+            backgroundId: playlist.items[0],
             screen: settings.windowMode ? undefined : targetScreen,
           },
         })

--- a/src/main/trpc/routes/playlist.ts
+++ b/src/main/trpc/routes/playlist.ts
@@ -92,8 +92,10 @@ export const playlistRouter = trpc.router({
         return { success: false, error: BACKEND_NOT_INSTALLED_ERROR_MESSAGE }
       }
 
-      // Persist lastAppliedAt so the frontend can sort by recency
-      await playlistService.stampLastApplied(input.playlistName)
+      const preparedPlaylist = await playlistService.preparePlaylistForStart(input.playlistName)
+      if (!preparedPlaylist) {
+        return { success: false, error: 'Playlist not found' }
+      }
 
       // Get target screen
       let targetScreen = input.screen
@@ -138,7 +140,7 @@ export const playlistRouter = trpc.router({
           proc,
           args,
           options: {
-            backgroundId: playlist.items[0],
+            backgroundId: preparedPlaylist.items[0],
             screen: settings.windowMode ? undefined : targetScreen,
           },
         })

--- a/src/main/trpc/routes/settings.test.ts
+++ b/src/main/trpc/routes/settings.test.ts
@@ -29,12 +29,12 @@ vi.mock('../../services/wallpaper/wallpaper', () => ({
   wallpaperService: mockWallpaperService,
 }))
 
-vi.mock('../../services/flatpak', () => ({
+vi.mock('../../utils/host', () => ({
   isFlatpak: (...args: unknown[]) => mockIsFlatpak(...args),
   setFlatpakBypass: (...args: unknown[]) => mockSetFlatpakBypass(...args),
 }))
 
-vi.mock('../../services/autostart', () => ({
+vi.mock('../../utils/autostart', () => ({
   setAutostart: (...args: unknown[]) => mockSetAutostart(...args),
 }))
 

--- a/src/main/trpc/routes/wallpaper.test.ts
+++ b/src/main/trpc/routes/wallpaper.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../services/settings', () => ({
 }))
 
 vi.mock('../../services/compatibility', () => ({
+  compatibilityService: mockCompatibilityInstance,
   CompatibilityService: {
     getInstance: () => mockCompatibilityInstance,
   },


### PR DESCRIPTION
 #81

When a playlist is set to **random** order, `linux-wallpaperengine` always starts from the same wallpaper — the first item in the playlist. Random ordering only takes effect on *subsequent* transitions.

## Root cause
Upstream `linux-wallpaperengine` loads `playlist.items.front()` before its random ordering logic runs, so the persisted first item is always shown first regardless of the `random` setting.

## Fix
- Shuffle the persisted item order for `random` playlists immediately before starting the backend, so the forced first item is itself random (Fisher–Yates via `node:crypto.randomInt`, with a guard that re-swaps when the shuffle leaves the original first item in place).
- Replace `stampLastApplied` with `preparePlaylistForStart`, which stamps `lastAppliedAt`, applies the random-start shuffle, and returns the prepared playlist so the backend is spawned with the correct `backgroundId`.
- Register the prepared first wallpaper in active playlist metadata.
- Add focused tests for the shuffle util and the playlist router; repair existing router test mocks so the full suite exercises current module imports.

## Testing
- `bun run test src/main/services/playlists/playlist.utils.test.ts src/main/trpc/routes/playlist.test.ts` — 6 tests passed
- `bun run test` — 67 tests passed
- `bun run typecheck` — passed
- `bun run lint` — passed (8 pre-existing unrelated warnings)
