### PR TITLE
Fix: multi-screen playlist and wallpapers

### DIFF
--- a/src/main/services/playlists/playlist.ts
+++ b/src/main/services/playlists/playlist.ts
@@ -1,22 +1,12 @@
 import * as fs from 'node:fs/promises'
 import type { Playlist } from '../../../shared/constants/playlist'
 import { storeService, type ActivePlaylistInfo } from '../store'
-import { invalidationService } from '../invalidation'
 import { findSteamConfigPath, ensureSteamConfigPath, readSteamConfig, writeSteamConfig, experimentalRandomizeStartItem } from './playlist.utils'
 
 class PlaylistService {
   private static instance: PlaylistService | null = null
   private configPath: string | null = null
   private playlistStore = storeService.activeWallpapers
-
-  private constructor() {
-    // When a wallpaper is applied directly, clear the active playlist
-    invalidationService.subscribe((key) => {
-      if (key === 'wallpaper.applied') {
-        this.clearActivePlaylist()
-      }
-    })
-  }
 
   static getInstance(): PlaylistService {
     if (!PlaylistService.instance) {
@@ -165,15 +155,38 @@ class PlaylistService {
 
   // ── Active playlist state ──────────────────────────────────────────────
 
-  getActivePlaylist(): ActivePlaylistInfo | null {
-    return this.playlistStore.get('activePlaylist')
+  getActivePlaylists(): ActivePlaylistInfo[] {
+    return Object.values(this.getActivePlaylistEntries())
   }
 
-  setActivePlaylist(name: string, screen: string): void {
-    this.playlistStore.set('activePlaylist', { name, screen })
+  getActivePlaylistEntries(): Record<string, ActivePlaylistInfo> {
+    const entries = this.playlistStore.get('activePlaylists') ?? {}
+    const legacy = this.playlistStore.get('activePlaylist')
+    if (!legacy || entries[legacy.screen]) return entries
+    return { ...entries, [legacy.screen]: legacy }
   }
 
-  clearActivePlaylist(): void {
+  setActivePlaylist(name: string, screens: string[]): void {
+    const entries = this.getActivePlaylistEntries()
+    for (const screen of screens) {
+      entries[screen] = { name, screen }
+    }
+    this.playlistStore.set('activePlaylists', entries)
+    this.playlistStore.set('activePlaylist', null)
+  }
+
+  clearActivePlaylist(screens?: string[]): void {
+    if (!screens) {
+      this.playlistStore.set('activePlaylists', {})
+      this.playlistStore.set('activePlaylist', null)
+      return
+    }
+
+    const entries = this.getActivePlaylistEntries()
+    for (const screen of screens) {
+      delete entries[screen]
+    }
+    this.playlistStore.set('activePlaylists', entries)
     this.playlistStore.set('activePlaylist', null)
   }
 }

--- a/src/main/services/store.ts
+++ b/src/main/services/store.ts
@@ -10,6 +10,7 @@ export interface ActivePlaylistInfo {
 
 export interface ActiveWallpapersSchema {
   activeWallpapers: Record<string, ApplyWallpaperOptions>
+  activePlaylists: Record<string, ActivePlaylistInfo>
   activePlaylist: ActivePlaylistInfo | null
 }
 
@@ -34,6 +35,7 @@ class StoreService {
       name: 'active-wallpapers',
       defaults: {
         activeWallpapers: {},
+        activePlaylists: {},
         activePlaylist: null,
       },
     })

--- a/src/main/services/wallpaper/state-manager/state-manager.ts
+++ b/src/main/services/wallpaper/state-manager/state-manager.ts
@@ -86,6 +86,44 @@ class WallpaperStateManager implements IStateManager {
     return { remaining }
   }
 
+  releaseMany(screens: string[]): { remaining: Array<{ screen: string, options: ApplyWallpaperOptions }>, released: string[] } {
+    const targets = new Set(screens)
+    const remaining: Array<{ screen: string, options: ApplyWallpaperOptions }> = []
+    const released: string[] = []
+    const procs = new Set<ChildProcess>()
+
+    for (const screen of targets) {
+      const proc = this.runningProcesses.get(screen)
+      if (proc) procs.add(proc)
+      if (this.activeWallpapers.has(screen)) released.push(screen)
+    }
+
+    for (const proc of procs) {
+      const group = this.processScreenGroups.get(proc)
+      if (group) {
+        for (const screen of group) {
+          if (targets.has(screen)) continue
+          const opts = this.activeWallpapers.get(screen)
+          if (opts) remaining.push({ screen, options: opts })
+        }
+        for (const screen of group) {
+          if (this.runningProcesses.get(screen) === proc) {
+            this.runningProcesses.delete(screen)
+          }
+        }
+        this.processScreenGroups.delete(proc)
+      }
+      try { proc.kill('SIGKILL') } catch { /* already dead */ }
+    }
+
+    for (const screen of targets) {
+      this.activeWallpapers.delete(screen)
+    }
+    this.save()
+
+    return { remaining, released }
+  }
+
   // Remove a process and all of its screens from the active state without
   // killing it. Used when a process exits unexpectedly so it no longer shows
   // as applied. No-op when state has already been released by an explicit stop.

--- a/src/main/services/wallpaper/wallpaper.interface.ts
+++ b/src/main/services/wallpaper/wallpaper.interface.ts
@@ -22,7 +22,7 @@ export interface IWallpaperService {
   apply(target: ApplyTarget): Promise<MutationResult>
 
   // Stop one screen or all
-  stop(screen?: string): Promise<{ success: boolean }>
+  stop(screen?: string | string[]): Promise<MutationResult>
 
   // Per-wallpaper override CRUD
   overrides(mutation: OverrideMutation): Promise<WallpaperOverrides | void>

--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -10,6 +10,7 @@ import { WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
 import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE, type ApplyWallpaperOptions, type Wallpaper, type WallpaperOverrides } from '../../../shared/constants/wallpaper'
 import { invalidationService } from '../invalidation'
 import { compatibilityService } from '../compatibility'
+import { playlistService } from '../playlists/playlist'
 import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry, resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir, resolveTimedCache, type TimedCache } from './wallpaper.utils'
 import { wallpaperStateManager } from './state-manager/state-manager'
 import type { IWallpaperService } from './wallpaper.interface'
@@ -58,8 +59,8 @@ class WallpaperService implements IWallpaperService {
       case 'wallpaper':
         return this.applyWallpaper(target.options)
       case 'register':
-        this.registerProcess(target.screen, target.proc, target.args, target.options)
-        return { success: true }
+        this.registerProcess(target.screens ?? [target.screen ?? 'default'], target.proc, target.args, target.options)
+        return { success: true, screens: target.screens ?? [target.screen ?? 'default'] }
       case 'reapply':
         return this.reapplyAll()
     }
@@ -67,25 +68,30 @@ class WallpaperService implements IWallpaperService {
 
   // ── Stop ───────────────────────────────────────────────────────────────
 
-  async stop(screen?: string): Promise<{ success: boolean }> {
+  async stop(screen?: string | string[]): Promise<MutationResult> {
     const settings = await settingsService.loadSettings()
-    if (screen && !settings.windowMode) {
-      const { remaining } = this.state.release(screen)
+    const screens = Array.isArray(screen) ? screen : screen ? [screen] : []
+    if (screens.length > 0 && !settings.windowMode) {
+      const { remaining, released } = this.state.releaseMany(screens)
       // Kill any orphaned processes for this screen
-      try {
-        await hostExecAsync(`pkill -9 -f "linux-wallpaperengine.*--screen-root.*${screen}"`)
-      } catch { /* no process found is ok */ }
+      for (const screen of screens) {
+        try {
+          await hostExecAsync(`pkill -9 -f "linux-wallpaperengine.*--screen-root.*${screen}"`)
+        } catch { /* no process found is ok */ }
+      }
       // Respawn remaining screens that shared the process
       await this.respawnGrouped(remaining)
       invalidationService.emit('wallpaper.stopped')
+      return { success: true, screens: released.length > 0 ? released : screens }
     } else {
+      const activeScreens = [...this.state.getActive().keys()]
       this.state.reset()
       try {
         await hostExecAsync('pkill -9 -f linux-wallpaperengine')
       } catch { /* no process found is ok */ }
       invalidationService.emit('wallpaper.stopped')
+      return { success: true, screens: activeScreens }
     }
-    return { success: true }
   }
 
   // ── Overrides ──────────────────────────────────────────────────────────
@@ -323,7 +329,7 @@ class WallpaperService implements IWallpaperService {
       if (await this.exitedEarly(proc)) {
         return { success: false }
       }
-      return { success: true }
+      return { success: true, screens: [screenKey] }
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to apply wallpaper' }
     }
@@ -357,7 +363,7 @@ class WallpaperService implements IWallpaperService {
       if (await this.exitedEarly(proc)) {
         return { success: false }
       }
-      return { success: true }
+      return { success: true, screens }
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to apply wallpaper' }
     }
@@ -376,6 +382,7 @@ class WallpaperService implements IWallpaperService {
     proc.once('exit', () => {
       const { screens } = this.state.cleanupExitedProcess(proc)
       if (screens.length > 0) {
+        playlistService.clearActivePlaylist(screens)
         invalidationService.emit('wallpaper.stopped')
       }
     })
@@ -399,22 +406,24 @@ class WallpaperService implements IWallpaperService {
     })
   }
 
-  private registerProcess(screen: string, proc: import('node:child_process').ChildProcess, args: string[], options: ApplyWallpaperOptions): void {
-    const screenKey = screen ?? 'default'
-    const existing = this.state.getProcess(screenKey)
-    if (existing) {
-      this.state.release(screenKey)
+  private registerProcess(screens: string[], proc: import('node:child_process').ChildProcess, args: string[], options: ApplyWallpaperOptions): void {
+    for (const screen of screens) {
+      const existing = this.state.getProcess(screen)
+      if (existing) {
+        this.state.release(screen)
+      }
     }
     proc.unref()
     compatibilityService.monitorProcess(proc, options.backgroundId)
     proc.once('exit', () => {
       const { screens } = this.state.cleanupExitedProcess(proc)
       if (screens.length > 0) {
+        playlistService.clearActivePlaylist(screens)
         invalidationService.emit('wallpaper.stopped')
       }
     })
-    this.state.register([screenKey], proc, options)
-    this.captureDebugLogs(proc, screenKey, args)
+    this.state.register(screens, proc, options)
+    this.captureDebugLogs(proc, screens[0] ?? 'default', args)
   }
 
   // ── Private: reapply ───────────────────────────────────────────────────

--- a/src/main/services/wallpaper/wallpaper.types.ts
+++ b/src/main/services/wallpaper/wallpaper.types.ts
@@ -8,6 +8,7 @@ import type {
 export interface MutationResult {
   success: boolean
   error?: string
+  screens?: string[]
 }
 
 export interface ActiveWallpaperEntry {
@@ -41,5 +42,5 @@ export type ServiceAction =
 
 export type ApplyTarget =
   | { kind: 'wallpaper'; options: ApplyWallpaperOptions }
-  | { kind: 'register'; screen: string; proc: import('node:child_process').ChildProcess; args: string[]; options: ApplyWallpaperOptions }
+  | { kind: 'register'; screen?: string; screens?: string[]; proc: import('node:child_process').ChildProcess; args: string[]; options: ApplyWallpaperOptions }
   | { kind: 'reapply' }

--- a/src/main/trpc/routes/playlist.test.ts
+++ b/src/main/trpc/routes/playlist.test.ts
@@ -11,7 +11,7 @@ const { mockPlaylistService, mockWallpaperService, mockSettingsService, mockDisp
     updatePlaylist: vi.fn(),
     deletePlaylist: vi.fn(),
     stampLastApplied: vi.fn(),
-    getActivePlaylist: vi.fn(),
+    getActivePlaylists: vi.fn(),
     setActivePlaylist: vi.fn(),
     clearActivePlaylist: vi.fn(),
   },
@@ -84,7 +84,10 @@ beforeEach(() => {
   mockSettingsService.loadSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
   mockSettingsService.settingsToArgs.mockReturnValue([])
   mockSettingsService.getSetting.mockReturnValue(false)
-  mockDisplayService.detectDisplays.mockResolvedValue([{ name: 'HDMI-1', primary: true }])
+  mockDisplayService.detectDisplays.mockResolvedValue([
+    { name: 'HDMI-1', primary: true },
+    { name: 'DP-1', primary: false },
+  ])
   mockHost.hostCommandExists.mockResolvedValue(true)
   mockHost.hostSpawn.mockReturnValue(new EventEmitter())
   mockWallpaperUtils.resolveWallpaperEngineAssetsDir.mockResolvedValue('/assets')
@@ -104,6 +107,29 @@ describe('playlistRouter', () => {
         '--assets-dir',
         '/assets',
       ], expect.any(Object))
+      expect(mockWallpaperService.apply).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'register',
+        screens: ['HDMI-1'],
+      }))
+      expect(mockPlaylistService.setActivePlaylist).toHaveBeenCalledWith('Random Mix', ['HDMI-1'])
+    })
+
+    it('starts a playlist on all detected screens when no screen is selected', async () => {
+      await caller.start({ playlistName: 'Random Mix' })
+
+      expect(mockHost.hostSpawn).toHaveBeenCalledWith('linux-wallpaperengine', [
+        '--screen-root',
+        'HDMI-1',
+        '--screen-root',
+        'DP-1',
+        '--playlist',
+        'Random Mix',
+        '--assets-dir',
+        '/assets',
+      ], expect.any(Object))
+      expect(mockWallpaperService.stop).toHaveBeenCalledWith(['HDMI-1', 'DP-1'])
+      expect(mockPlaylistService.clearActivePlaylist).toHaveBeenCalledWith(['HDMI-1', 'DP-1'])
+      expect(mockPlaylistService.setActivePlaylist).toHaveBeenCalledWith('Random Mix', ['HDMI-1', 'DP-1'])
     })
 
     it('does not stamp or spawn when the backend is missing', async () => {
@@ -114,6 +140,48 @@ describe('playlistRouter', () => {
       expect(result.success).toBe(false)
       expect(mockPlaylistService.stampLastApplied).not.toHaveBeenCalled()
       expect(mockHost.hostSpawn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('stop', () => {
+    it('stops only matching playlist screens', async () => {
+      mockPlaylistService.getActivePlaylists.mockReturnValue([
+        { name: 'Random Mix', screen: 'HDMI-1' },
+        { name: 'Other Mix', screen: 'DP-1' },
+      ])
+
+      await caller.stop({ playlistName: 'Random Mix' })
+
+      expect(mockWallpaperService.stop).toHaveBeenCalledWith(['HDMI-1'])
+      expect(mockPlaylistService.clearActivePlaylist).toHaveBeenCalledWith(['HDMI-1'])
+    })
+
+    it('restarts remaining screens with playlist args and current settings when stopping one screen', async () => {
+      mockPlaylistService.getActivePlaylists.mockReturnValue([
+        { name: 'Random Mix', screen: 'HDMI-1' },
+        { name: 'Random Mix', screen: 'DP-1' },
+      ])
+      mockSettingsService.settingsToArgs.mockReturnValue(['--fps', '30'])
+
+      await caller.stop({ playlistName: 'Random Mix', screen: 'HDMI-1' })
+
+      expect(mockWallpaperService.stop).toHaveBeenCalledWith(['HDMI-1', 'DP-1'])
+      expect(mockPlaylistService.clearActivePlaylist).toHaveBeenCalledWith(['HDMI-1', 'DP-1'])
+      expect(mockHost.hostSpawn).toHaveBeenCalledWith('linux-wallpaperengine', [
+        '--screen-root',
+        'DP-1',
+        '--playlist',
+        'Random Mix',
+        '--fps',
+        '30',
+        '--assets-dir',
+        '/assets',
+      ], expect.any(Object))
+      expect(mockWallpaperService.apply).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'register',
+        screens: ['DP-1'],
+      }))
+      expect(mockPlaylistService.setActivePlaylist).toHaveBeenCalledWith('Random Mix', ['DP-1'])
     })
   })
 })

--- a/src/main/trpc/routes/playlist.ts
+++ b/src/main/trpc/routes/playlist.ts
@@ -18,6 +18,71 @@ const playlistSettingsSchema = z.object({
   videosequence: z.boolean(),
 })
 
+async function startPlaylistProcess(playlistName: string, screens: string[], stampLastApplied: boolean) {
+  const playlist = await playlistService.getPlaylist(playlistName)
+  if (!playlist) {
+    return { success: false, error: 'Playlist not found' }
+  }
+
+  if (playlist.items.length === 0) {
+    return { success: false, error: 'Playlist has no wallpapers' }
+  }
+
+  if (!await hostCommandExists('linux-wallpaperengine')) {
+    return { success: false, error: BACKEND_NOT_INSTALLED_ERROR_MESSAGE }
+  }
+
+  if (stampLastApplied) {
+    await playlistService.stampLastApplied(playlistName)
+  }
+
+  const settings = await settingsService.loadSettings()
+  const screenKeys = settings.windowMode ? ['default'] : screens
+  const settingsArgs = settingsService.settingsToArgs(settings)
+  const assetsDir = settings.assetsDir ?? await resolveWallpaperEngineAssetsDir()
+  const args: string[] = []
+  if (!settings.windowMode) {
+    for (const screen of screenKeys) {
+      args.push('--screen-root', screen)
+    }
+  }
+  args.push('--playlist', playlistName)
+  args.push(...settingsArgs)
+  if (!settings.assetsDir && assetsDir) {
+    args.push('--assets-dir', assetsDir)
+  }
+
+  try {
+    const debugMode = settingsService.getSetting('debugMode')
+    const proc = hostSpawn('linux-wallpaperengine', args, {
+      detached: true,
+      stdio: debugMode
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'ignore', 'pipe'],
+    })
+
+    await wallpaperService.apply({
+      kind: 'register',
+      screens: screenKeys,
+      proc,
+      args,
+      options: {
+        backgroundId: playlist.items[0],
+        screen: settings.windowMode ? undefined : screens.length === 1 ? screens[0] : undefined,
+      },
+    })
+
+    playlistService.setActivePlaylist(playlistName, screenKeys)
+
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to apply playlist',
+    }
+  }
+}
+
 export const playlistRouter = trpc.router({
   // List all playlists
   list: trpc.procedure.query(async () => {
@@ -64,13 +129,42 @@ export const playlistRouter = trpc.router({
     }),
 
   // Stop the currently active playlist
-  stop: trpc.procedure.mutation(async () => {
-    const active = playlistService.getActivePlaylist()
-    if (!active) return { success: true }
-    await wallpaperService.stop(active.screen)
-    playlistService.clearActivePlaylist()
-    return { success: true }
-  }),
+  stop: trpc.procedure
+    .input(z.object({
+      screen: z.string().optional(),
+      playlistName: z.string().optional(),
+    }).optional())
+    .mutation(async ({ input }) => {
+      const active = playlistService.getActivePlaylists()
+      const targetScreens = active
+        .filter(entry => (!input?.screen || entry.screen === input.screen) && (!input?.playlistName || entry.name === input.playlistName))
+        .map(entry => entry.screen)
+      if (targetScreens.length === 0) return { success: true }
+
+      const targetScreenSet = new Set(targetScreens)
+      const affectedPlaylistNames = new Set(
+        active
+          .filter(entry => targetScreenSet.has(entry.screen))
+          .map(entry => entry.name)
+      )
+
+      for (const playlistName of affectedPlaylistNames) {
+        const playlistScreens = active
+          .filter(entry => entry.name === playlistName)
+          .map(entry => entry.screen)
+        const remainingScreens = playlistScreens.filter(screen => !targetScreenSet.has(screen))
+
+        await wallpaperService.stop(playlistScreens)
+        playlistService.clearActivePlaylist(playlistScreens)
+
+        if (remainingScreens.length > 0) {
+          const result = await startPlaylistProcess(playlistName, remainingScreens, false)
+          if (!result.success) return result
+        }
+      }
+
+      return { success: true }
+    }),
 
   // Start playlist on screen
   start: trpc.procedure
@@ -79,83 +173,21 @@ export const playlistRouter = trpc.router({
       screen: z.string().optional(),
     }))
     .mutation(async ({ input }) => {
-      const playlist = await playlistService.getPlaylist(input.playlistName)
-      if (!playlist) {
-        return { success: false, error: 'Playlist not found' }
-      }
-
-      if (playlist.items.length === 0) {
-        return { success: false, error: 'Playlist has no wallpapers' }
-      }
-
-      if (!await hostCommandExists('linux-wallpaperengine')) {
-        return { success: false, error: BACKEND_NOT_INSTALLED_ERROR_MESSAGE }
-      }
-
-      // Persist lastAppliedAt so the frontend can sort by recency
-      await playlistService.stampLastApplied(input.playlistName)
-
-      // Get target screen
-      let targetScreen = input.screen
-      if (!targetScreen) {
-        const displays = await displayService.detectDisplays()
-        const primary = displays.find(d => d.primary) ?? displays[0]
-        if (primary) {
-          targetScreen = primary.name
-        }
-      }
-
-      // Stop existing wallpaper on this screen first
-      await wallpaperService.stop(targetScreen)
-
-      // Build command args for playlist mode with user settings
       const settings = await settingsService.loadSettings()
-      const settingsArgs = settingsService.settingsToArgs(settings)
-      const assetsDir = settings.assetsDir ?? await resolveWallpaperEngineAssetsDir()
-      const args: string[] = []
-      if (targetScreen && !settings.windowMode) {
-        args.push('--screen-root', targetScreen)
-      }
-      args.push('--playlist', input.playlistName)
-      args.push(...settingsArgs)
-      if (!settings.assetsDir && assetsDir) {
-        args.push('--assets-dir', assetsDir)
-      }
+      const targetScreens = input.screen
+        ? [input.screen]
+        : settings.windowMode
+          ? ['default']
+          : (await displayService.detectDisplays()).map(d => d.name)
 
-      try {
-        const debugMode = settingsService.getSetting('debugMode')
-        const proc = hostSpawn('linux-wallpaperengine', args, {
-          detached: true,
-          stdio: debugMode
-            ? ['ignore', 'pipe', 'pipe']
-            : ['ignore', 'ignore', 'pipe'],
-        })
+      await wallpaperService.stop(targetScreens)
+      playlistService.clearActivePlaylist(targetScreens)
 
-        const screenKey = settings.windowMode ? 'default' : (targetScreen ?? 'default')
-        await wallpaperService.apply({
-          kind: 'register',
-          screen: screenKey,
-          proc,
-          args,
-          options: {
-            backgroundId: playlist.items[0],
-            screen: settings.windowMode ? undefined : targetScreen,
-          },
-        })
-
-        playlistService.setActivePlaylist(input.playlistName, screenKey)
-
-        return { success: true }
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : 'Failed to apply playlist',
-        }
-      }
+      return startPlaylistProcess(input.playlistName, targetScreens, true)
     }),
 
   // Get currently active playlist info
   active: trpc.procedure.query(() => {
-    return playlistService.getActivePlaylist()
+    return playlistService.getActivePlaylists()
   }),
 })

--- a/src/main/trpc/routes/wallpaper.test.ts
+++ b/src/main/trpc/routes/wallpaper.test.ts
@@ -4,13 +4,16 @@ import type { Wallpaper, WallpaperOverrides } from '../../../shared/constants/wa
 
 // --- Mocks ---------------------------------------------------------------
 
-const { mockWallpaperService, mockSettingsService, mockCompatibilityInstance } = vi.hoisted(() => ({
+const { mockWallpaperService, mockPlaylistService, mockSettingsService, mockCompatibilityInstance } = vi.hoisted(() => ({
   mockWallpaperService: {
     query: vi.fn(),
     apply: vi.fn(),
     stop: vi.fn(),
     overrides: vi.fn(),
     diagnose: vi.fn(),
+  },
+  mockPlaylistService: {
+    clearActivePlaylist: vi.fn(),
   },
   mockSettingsService: {
     loadSettings: vi.fn(),
@@ -27,6 +30,10 @@ const { mockWallpaperService, mockSettingsService, mockCompatibilityInstance } =
 
 vi.mock('../../services/wallpaper/wallpaper', () => ({
   wallpaperService: mockWallpaperService,
+}))
+
+vi.mock('../../services/playlists/playlist', () => ({
+  playlistService: mockPlaylistService,
 }))
 
 vi.mock('../../services/settings', () => ({
@@ -204,14 +211,24 @@ describe('wallpaperRouter', () => {
       const result = await caller.setWallpaper({ backgroundId: '1' })
       expect(result).toEqual({ success: false, error: 'spawn failed' })
     })
+
+    it('should clear active playlist entries only for affected screens', async () => {
+      mockSettingsService.loadSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
+      mockWallpaperService.apply.mockResolvedValue({ success: true, screens: ['HDMI-1'] })
+
+      await caller.setWallpaper({ backgroundId: '1', screen: 'HDMI-1' })
+
+      expect(mockPlaylistService.clearActivePlaylist).toHaveBeenCalledWith(['HDMI-1'])
+    })
   })
 
   describe('stopWalpaper', () => {
     it('should stop a specific screen', async () => {
-      mockWallpaperService.stop.mockResolvedValue({ success: true })
+      mockWallpaperService.stop.mockResolvedValue({ success: true, screens: ['HDMI-1'] })
       const result = await caller.stopWalpaper({ screen: 'HDMI-1' })
       expect(mockWallpaperService.stop).toHaveBeenCalledWith('HDMI-1')
-      expect(result).toEqual({ success: true })
+      expect(mockPlaylistService.clearActivePlaylist).toHaveBeenCalledWith(['HDMI-1'])
+      expect(result).toEqual({ success: true, screens: ['HDMI-1'] })
     })
 
     it('should stop all when no screen given', async () => {

--- a/src/main/trpc/routes/wallpaper.ts
+++ b/src/main/trpc/routes/wallpaper.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { trpc } from '../trpc'
 import { wallpaperService } from '../../services/wallpaper/wallpaper'
+import { playlistService } from '../../services/playlists/playlist'
 import type { ApplyWallpaperOptions } from '../../../shared/constants/wallpaper'
 import type { DebugInfo } from '../../services/wallpaper/wallpaper.types'
 import { settingsService } from '../../services/settings'
@@ -76,14 +77,22 @@ export const wallpaperRouter = trpc.router({
         windowed: settings.windowMode ? parseWindowGeometry(settings.windowGeometry) : input.windowed,
       }
 
-      return wallpaperService.apply({ kind: 'wallpaper', options })
+      const result = await wallpaperService.apply({ kind: 'wallpaper', options })
+      if (result.success && result.screens) {
+        playlistService.clearActivePlaylist(result.screens)
+      }
+      return result
     }),
 
   // Stop wallpaper(s)
   stopWalpaper: trpc.procedure
     .input(z.object({ screen: z.string().optional() }).optional())
     .mutation(async ({ input }) => {
-      return wallpaperService.stop(input?.screen)
+      const result = await wallpaperService.stop(input?.screen)
+      if (result.success && result.screens) {
+        playlistService.clearActivePlaylist(result.screens)
+      }
+      return result
     }),
 
   // Get currently active wallpapers

--- a/src/renderer/components/layout/bottom-status-bar.tsx
+++ b/src/renderer/components/layout/bottom-status-bar.tsx
@@ -15,10 +15,15 @@ export function StatusBar({ className }: StatusBarProps) {
 
     const { data: displays = [] } = trpc.display.list.useQuery()
     const { data: settings } = trpc.settings.get.useQuery()
+    const { data: activePlaylists = [] } = trpc.playlist.active.useQuery(undefined, {
+        refetchInterval: 5000,
+        refetchOnMount: true,
+    })
 
 
 
     const stopMutation = trpc.wallpaper.stopWalpaper.useMutation()
+    const stopPlaylistMutation = trpc.playlist.stop.useMutation()
     const updateSettingsMutation = trpc.settings.update.useMutation()
     const utils = trpc.useUtils()
 
@@ -35,8 +40,17 @@ export function StatusBar({ className }: StatusBarProps) {
 
     const handleStop = async () => {
         if (!activeWallpaper) return
-        await stopMutation.mutateAsync({ screen: activeWallpaper.screen })
+        const activePlaylist = activePlaylists.find(entry => entry.screen === activeWallpaper.screen)
+        if (activePlaylist) {
+            await stopPlaylistMutation.mutateAsync({
+                playlistName: activePlaylist.name,
+                screen: activeWallpaper.screen,
+            })
+        } else {
+            await stopMutation.mutateAsync({ screen: activeWallpaper.screen })
+        }
         utils.wallpaper.getActiveWallpaper.invalidate()
+        utils.playlist.active.invalidate()
     }
 
     const handleMuteToggle = async () => {

--- a/src/renderer/components/playlist/playlist-row.tsx
+++ b/src/renderer/components/playlist/playlist-row.tsx
@@ -1,4 +1,4 @@
-import { Clock, Shuffle, MoreVertical, Pencil, Trash2, Images, CircleCheck } from "lucide-react"
+import { Clock, Shuffle, MoreVertical, Pencil, Trash2, Images } from "lucide-react"
 import { useState, useEffect } from "react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -25,9 +25,9 @@ interface PlaylistRowProps {
     playlist: Playlist
     wallpapers: Wallpaper[]
     isApplying: boolean
-    isActive: boolean
+    activeScreens: string[]
     onApply: (screen?: string) => Promise<void>
-    onStop: (screen?: string) => Promise<void>
+    onStop: (screen?: string | string[]) => Promise<void>
     onEdit: () => void
     onDelete: () => void
 }
@@ -36,7 +36,7 @@ export function PlaylistRow({
     playlist,
     wallpapers,
     isApplying,
-    isActive,
+    activeScreens,
     onApply,
     onStop,
     onEdit,
@@ -99,7 +99,7 @@ export function PlaylistRow({
                         onApply={onApply}
                         onStop={onStop}
                         isApplying={isApplying}
-                        isActive={isActive}
+                        activeScreens={activeScreens}
                         size="sm"
                     />
 
@@ -147,7 +147,7 @@ export function PlaylistRow({
                             >
 
                                 <div className="relative size-32 sm:size-36 md:size-40 lg:size-44 xl:size-48 rounded-lg overflow-hidden ring-1 ring-border/50 transition-all">
-                                    {!isActive && <div className="absolute inset-0 bg-gradient-to-t from-card/40 via-card/10 to-card/10 transition-opacity duration-300 group-hover:opacity-0 z-10" />}
+                                    {activeScreens.length === 0 && <div className="absolute inset-0 bg-gradient-to-t from-card/40 via-card/10 to-card/10 transition-opacity duration-300 group-hover:opacity-0 z-10" />}
 
                                     <img
                                         src={`local-file://${wallpaper.thumbnail ?? wallpaper.path}`}

--- a/src/renderer/components/wallpaper/apply-button.tsx
+++ b/src/renderer/components/wallpaper/apply-button.tsx
@@ -13,9 +13,9 @@ import { cn } from "@/lib/utils"
 
 interface ApplyButtonProps {
     onApply: (screen?: string) => Promise<void>
-    onStop?: (screen?: string) => Promise<void>
+    onStop?: (screen?: string | string[]) => Promise<void>
     isApplying: boolean
-    isActive?: boolean
+    activeScreens?: string[]
     label?: string
     applyingLabel?: string
     size?: "default" | "sm" | "lg" | "icon" | "icon-sm"
@@ -26,13 +26,15 @@ export function ApplyButton({
     onApply,
     onStop,
     isApplying,
-    isActive = false,
+    activeScreens = [],
     label = "Apply",
     applyingLabel = "Applying...",
     size = "default",
     className,
 }: ApplyButtonProps) {
     const { data: displays } = trpc.display.list.useQuery()
+    const activeScreenSet = React.useMemo(() => new Set(activeScreens), [activeScreens])
+    const isActive = activeScreenSet.size > 0
 
     return (
         <div className={className}>
@@ -44,7 +46,7 @@ export function ApplyButton({
                         "gap-2 rounded-r-none flex-1",
                         isActive && "text-destructive hover:bg-destructive/10 hover:text-destructive"
                     )}
-                    onClick={() => isActive && onStop ? onStop() : onApply()}
+                    onClick={() => isActive && onStop ? onStop(activeScreens) : onApply()}
                     disabled={isApplying}
                 >
                     {isApplying ? (
@@ -75,22 +77,25 @@ export function ApplyButton({
                     <DropdownMenuContent align="start" className="w-48">
                         {displays && displays.length > 0 && (
                             <>
-                                {displays.map((display) => (
-                                    <DropdownMenuItem
-                                        key={display.name}
-                                        onClick={() => isActive && onStop ? onStop(display.name) : onApply(display.name)}
-                                    >
-                                        {isActive ? <Square className="size-4" /> : <Monitor className="size-4" />}
-                                        {isActive ? `Stop on ${display.name}` : display.name}
-                                        {display.primary && (
-                                            <span className="ml-auto text-xs text-muted-foreground">Primary</span>
-                                        )}
-                                    </DropdownMenuItem>
-                                ))}
+                                {displays.map((display) => {
+                                    const isDisplayActive = activeScreenSet.has(display.name)
+                                    return (
+                                        <DropdownMenuItem
+                                            key={display.name}
+                                            onClick={() => isDisplayActive && onStop ? onStop(display.name) : onApply(display.name)}
+                                        >
+                                            {isDisplayActive ? <Square className="size-4" /> : <Monitor className="size-4" />}
+                                            {isDisplayActive ? `Stop on ${display.name}` : display.name}
+                                            {display.primary && (
+                                                <span className="ml-auto text-xs text-muted-foreground">Primary</span>
+                                            )}
+                                        </DropdownMenuItem>
+                                    )
+                                })}
                                 <DropdownMenuSeparator />
                             </>
                         )}
-                        <DropdownMenuItem onClick={() => isActive && onStop ? onStop() : onApply()}>
+                        <DropdownMenuItem onClick={() => isActive && onStop ? onStop(activeScreens) : onApply()}>
                             {isActive ? <Square className="size-4" /> : <Monitor className="size-4" />}
                             {isActive ? "Stop all" : "All displays"}
                         </DropdownMenuItem>

--- a/src/renderer/components/wallpaper/details-card/wallpaper-details.tsx
+++ b/src/renderer/components/wallpaper/details-card/wallpaper-details.tsx
@@ -44,9 +44,9 @@ export function WallpaperDetails({ wallpaper, onClose, onUnsubscribe }: Wallpape
         refetchInterval: 5000,
     })
 
-    const isActive = activeWallpapers.some(
-        w => w.wallpaper.backgroundId === backgroundId
-    )
+    const activeScreens = activeWallpapers
+        .filter(w => w.wallpaper.backgroundId === backgroundId)
+        .map(w => w.screen)
 
     const handleApply = async (screen?: string) => {
         if (!backgroundId) return
@@ -83,10 +83,11 @@ export function WallpaperDetails({ wallpaper, onClose, onUnsubscribe }: Wallpape
         }
     }
 
-    const handleStop = async (screen?: string) => {
-            await stopMutation.mutateAsync({ screen })
-            await utils.wallpaper.getActiveWallpaper.invalidate()
-            await utils.playlist.active.invalidate()
+    const handleStop = async (screen?: string | string[]) => {
+        const screens = Array.isArray(screen) ? screen : [screen]
+        await Promise.all(screens.map(screen => stopMutation.mutateAsync({ screen })))
+        await utils.wallpaper.getActiveWallpaper.invalidate()
+        await utils.playlist.active.invalidate()
     }
 
     const handleUnsubscribe = async () => {
@@ -121,7 +122,7 @@ export function WallpaperDetails({ wallpaper, onClose, onUnsubscribe }: Wallpape
                             onApply={handleApply}
                             onStop={handleStop}
                             isApplying={isApplying}
-                            isActive={isActive}
+                            activeScreens={activeScreens}
                             className="flex-1"
                         />
                         {canUnsubscribe && (

--- a/src/renderer/components/workshop/action-buttons.tsx
+++ b/src/renderer/components/workshop/action-buttons.tsx
@@ -16,10 +16,10 @@ interface WorkshopActionButtonsProps {
     onDownload: () => void
     onUnsubscribe: () => void
     onApply: (screen?: string) => Promise<void>
-    onStop: (screen?: string) => Promise<void>
+    onStop: (screen?: string | string[]) => Promise<void>
     isApplying: boolean
     isUnsubscribing?: boolean
-    isActive: boolean
+    activeScreens?: string[]
 }
 
 export function WorkshopActionButtons({
@@ -32,7 +32,7 @@ export function WorkshopActionButtons({
     onStop,
     isApplying,
     isUnsubscribing = false,
-    isActive,
+    activeScreens,
 }: WorkshopActionButtonsProps) {
     const isSubscribed = wallpaperPath != null
 
@@ -66,7 +66,7 @@ export function WorkshopActionButtons({
                 onApply={onApply}
                 onStop={onStop}
                 isApplying={isApplying}
-                isActive={isActive}
+                activeScreens={activeScreens}
                 className="flex-1"
             />
             <UnsubscribeButton onClick={onUnsubscribe} disabled={isUnsubscribing} />

--- a/src/renderer/components/workshop/workshop-wallpaper-details.tsx
+++ b/src/renderer/components/workshop/workshop-wallpaper-details.tsx
@@ -62,9 +62,9 @@ export function WorkshopWallpaperDetails({ wallpaper, onClose }: WorkshopWallpap
         }
     }, [isDownloading, wallpaperPath])
 
-    const isActive = activeWallpapers.some(
-        w => w.wallpaper.backgroundId === wallpaperPath
-    )
+    const activeScreens = activeWallpapers
+        .filter(w => w.wallpaper.backgroundId === wallpaperPath)
+        .map(w => w.screen)
 
     const handleDownload = () => {
         subscribeMutation.mutate({ workshopId })
@@ -110,8 +110,9 @@ export function WorkshopWallpaperDetails({ wallpaper, onClose }: WorkshopWallpap
         }
     }
 
-    const handleStop = async (screen?: string) => {
-        await stopMutation.mutateAsync({ screen })
+    const handleStop = async (screen?: string | string[]) => {
+        const screens = Array.isArray(screen) ? screen : [screen]
+        await Promise.all(screens.map(screen => stopMutation.mutateAsync({ screen })))
         await utils.wallpaper.getActiveWallpaper.invalidate()
         await utils.playlist.active.invalidate()
     }
@@ -132,7 +133,7 @@ export function WorkshopWallpaperDetails({ wallpaper, onClose }: WorkshopWallpap
                         onStop={handleStop}
                         isApplying={isApplying}
                         isUnsubscribing={unsubscribeMutation.isPending}
-                        isActive={isActive}
+                        activeScreens={activeScreens}
                     />
                     <ErrorMessage
                         message={errorMessage}

--- a/src/renderer/routes/playlists/index.tsx
+++ b/src/renderer/routes/playlists/index.tsx
@@ -55,7 +55,6 @@ function PlaylistsPage() {
     const deleteMutation = trpc.playlist.delete.useMutation()
     const applyMutation = trpc.playlist.start.useMutation()
     const stopMutation = trpc.playlist.stop.useMutation()
-    const stopWallpaperMutation = trpc.wallpaper.stopWalpaper.useMutation()
     const utils = trpc.useUtils()
 
     const handleApply = async (playlistName: string, screen?: string) => {
@@ -85,11 +84,13 @@ function PlaylistsPage() {
         }
     }
 
-    const handleStop = async (screen?: string) => {
-        if (screen) {
-            await stopWallpaperMutation.mutateAsync({ screen })
+    const handleStop = async (playlistName: string, screen?: string | string[]) => {
+        if (Array.isArray(screen)) {
+            await stopMutation.mutateAsync({ playlistName })
+        } else if (screen) {
+            await stopMutation.mutateAsync({ playlistName, screen })
         } else {
-            await stopMutation.mutateAsync()
+            await stopMutation.mutateAsync({ playlistName })
         }
         await utils.playlist.active.invalidate()
         await utils.wallpaper.getActiveWallpaper.invalidate()
@@ -188,7 +189,9 @@ function PlaylistsPage() {
                 <div className="flex flex-col gap-4">
                     {filteredPlaylists.map((playlist) => {
                         const isApplying = applyingPlaylist === playlist.name
-                        const isActive = activePlaylist?.name === playlist.name
+                        const activeScreens = activePlaylist
+                            ?.filter(entry => entry.name === playlist.name)
+                            .map(entry => entry.screen) ?? []
 
                         return (
                             <PlaylistRow
@@ -196,9 +199,9 @@ function PlaylistsPage() {
                                 playlist={playlist}
                                 wallpapers={wallpapers}
                                 isApplying={isApplying}
-                                isActive={isActive}
+                                activeScreens={activeScreens}
                                 onApply={(screen) => handleApply(playlist.name, screen)}
-                                onStop={handleStop}
+                                onStop={(screen) => handleStop(playlist.name, screen)}
                                 onEdit={() => handleEdit(playlist)}
                                 onDelete={() => handleDelete(playlist.name)}
                             />


### PR DESCRIPTION
Addresses #80 

- Replace single `activePlaylist` with per-screen `activePlaylists` map
- Add `screens` array to `MutationResult` to track affected displays
- Support starting/stopping playlists on specific screens or all screens
- Restart remaining screens when stopping one screen from a multi-screen playlist
- Clear active playlist state when wallpaper process exits
- Add `releaseMany` to state manager for batch screen release
- Migrate legacy single
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->