### PR TITLE
fix tray icon on wayland

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,6 +30,9 @@ const resolveAssetPath = (assetName: string): string => {
 }
 
 const appIcon = nativeImage.createFromPath(resolveAssetPath('transparent-logo.png'))
+// Standard tray icon size (22x22 ensures pixmap data is sent via SNI on Wayland)
+const TRAY_ICON_SIZE = 22
+const trayIcon = appIcon.resize({ width: TRAY_ICON_SIZE, height: TRAY_ICON_SIZE })
 
 const shouldMinimizeOnClose = (): boolean => {
   return settings.getSetting('enableSystemTray') && settings.getSetting('minimizeOnClose')
@@ -90,7 +93,7 @@ const createWindow = () => {
 // Initialize the system tray with context menu
 const initializeTray = (mainWindow: BrowserWindow): void => {
   if (tray !== null) return
-  tray = new Tray(appIcon)
+  tray = new Tray(trayIcon)
 
   const toggleMainWindow = (): void => {
     if (!mainWindow.isVisible()) {


### PR DESCRIPTION
<img width="180" height="48" alt="image" src="https://github.com/user-attachments/assets/d6be57c2-140f-427c-a0c0-4e389914f8c0" />
I had the same issue as is described in #97 and decided to fix it since it's just two lines. As I mentioned in that issue, it's got something to do with the differences in how Wayland and X11 handle system tray icons. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->