### PR TITLE
Fix settings grid section alignment

### DIFF
--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -131,7 +131,7 @@ function SettingsPage() {
                 }
             />
 
-            <div className="grid grid-cols-1 gap-6 2xl:grid-cols-2">
+            <div className="grid grid-cols-1 items-start gap-6 2xl:grid-cols-2">
                 {/* General Section */}
                 <SettingsSection
                     icon={Settings}


### PR DESCRIPTION
## Summary
- Align settings grid sections to the top of their rows.
- Prevent uneven vertical placement in two-column layouts.

## Testing
- Not run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->