### PR TITLE
Keyboard navigation 1/3: semantic controls and focus foundation

### DIFF
--- a/src/renderer/components/layout/app-shell.tsx
+++ b/src/renderer/components/layout/app-shell.tsx
@@ -9,6 +9,8 @@ import { WallpaperBackground } from "@/components/wallpaper/wallpaper-background
 import { UpdateReminderBanner } from "@/components/update-reminder-banner"
 import { ScanReminderBanner } from "@/components/scan-reminder-banner"
 
+const MAIN_CONTENT_ID = "main-content"
+
 interface AppShellProps {
     children: React.ReactNode
     className?: string
@@ -24,7 +26,13 @@ export function AppShell({ children, className }: AppShellProps) {
                 style={{ "--status-bar-h": settings?.showStatusBar ? STATUS_BAR_HEIGHT : "0rem" } as React.CSSProperties}
             >
                 <a
-                    href="#main-content"
+                    href={`#${MAIN_CONTENT_ID}`}
+                    onClick={(event) => {
+                        event.preventDefault()
+                        const main = document.getElementById(MAIN_CONTENT_ID)
+                        main?.focus()
+                        main?.scrollIntoView({ block: "start" })
+                    }}
                     className="absolute left-3 top-3 z-50 -translate-y-16 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow-md transition-transform focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
                 >
                     Skip to content
@@ -38,9 +46,9 @@ export function AppShell({ children, className }: AppShellProps) {
                             <ScanReminderBanner />
                         </div>
                         <main
-                            id="main-content"
+                            id={MAIN_CONTENT_ID}
                             tabIndex={-1}
-                            className={cn("min-h-0 flex-1 overflow-auto px-[2.5%] pb-4 outline-none scrollbar-styled", className)}
+                            className={cn("min-h-0 flex-1 overflow-auto px-[2.5%] pb-4 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring scrollbar-styled", className)}
                         >
                             {children}
                         </main>

--- a/src/renderer/components/layout/app-shell.tsx
+++ b/src/renderer/components/layout/app-shell.tsx
@@ -23,6 +23,12 @@ export function AppShell({ children, className }: AppShellProps) {
                 className="relative flex h-screen w-full flex-col overflow-hidden bg-background"
                 style={{ "--status-bar-h": settings?.showStatusBar ? STATUS_BAR_HEIGHT : "0rem" } as React.CSSProperties}
             >
+                <a
+                    href="#main-content"
+                    className="absolute left-3 top-3 z-50 -translate-y-16 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow-md transition-transform focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+                >
+                    Skip to content
+                </a>
                 {settings?.dynamicBackground && <WallpaperBackground />}
                 <div className="relative z-10 flex min-h-0 flex-1">
                     <Sidebar className="z-10" />
@@ -31,7 +37,11 @@ export function AppShell({ children, className }: AppShellProps) {
                             <UpdateReminderBanner />
                             <ScanReminderBanner />
                         </div>
-                        <main className={cn("min-h-0 flex-1 overflow-auto px-[2.5%] pb-4 scrollbar-styled", className)}>
+                        <main
+                            id="main-content"
+                            tabIndex={-1}
+                            className={cn("min-h-0 flex-1 overflow-auto px-[2.5%] pb-4 outline-none scrollbar-styled", className)}
+                        >
                             {children}
                         </main>
                     </div>

--- a/src/renderer/components/layout/bottom-status-bar.tsx
+++ b/src/renderer/components/layout/bottom-status-bar.tsx
@@ -119,9 +119,9 @@ export function StatusBar({ className }: StatusBarProps) {
                     {hasMultipleScreens && (
                         <Tooltip>
                             <TooltipTrigger asChild>
-                                <span className="rounded-full bg-secondary px-1.5 py-0.5 text-xs">
+                                <button type="button" className="rounded-full bg-secondary px-1.5 py-0.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
                                     {activeWallpapers.length}/{displays.length} active
-                                </span>
+                                </button>
                             </TooltipTrigger>
                             <TooltipContent className="whitespace-pre-line">{screensTooltip}</TooltipContent>
                         </Tooltip>
@@ -155,9 +155,9 @@ export function StatusBar({ className }: StatusBarProps) {
                             {otherActiveCount > 0 && (
                                 <Tooltip>
                                     <TooltipTrigger asChild>
-                                        <span className="text-xs text-muted-foreground/70">
+                                        <button type="button" className="rounded-sm text-xs text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
                                             +{otherActiveCount} more
-                                        </span>
+                                        </button>
                                     </TooltipTrigger>
                                     <TooltipContent className="whitespace-pre-line">{screensTooltip}</TooltipContent>
                                 </Tooltip>
@@ -181,6 +181,7 @@ export function StatusBar({ className }: StatusBarProps) {
                     className="size-7"
                     onClick={handleMuteToggle}
                     disabled={!activeWallpaper || !settings}
+                    aria-label={settings?.silent ? "Unmute wallpaper" : "Mute wallpaper"}
                     title={settings?.silent ? "Unmute" : "Mute"}
                 >
                     {settings?.silent ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
@@ -191,6 +192,7 @@ export function StatusBar({ className }: StatusBarProps) {
                     className="size-7"
                     onClick={handleStop}
                     disabled={!activeWallpaper}
+                    aria-label="Stop wallpaper"
                     title="Stop wallpaper"
                 >
                     <Square className="size-3.5" />

--- a/src/renderer/components/playlist/selected-chips.tsx
+++ b/src/renderer/components/playlist/selected-chips.tsx
@@ -26,20 +26,23 @@ export function SelectedChips({ wallpapers, onRemove, onChipClick }: SelectedChi
                         initial={{ opacity: 0, scale: 0.8 }}
                         animate={{ opacity: 1, scale: 1 }}
                         exit={{ opacity: 0, scale: 0.8 }}
-                        onClick={() => onChipClick(wallpaper.path)}
-                        className="flex cursor-pointer items-center gap-2 rounded-lg border border-primary/20 bg-primary/10 px-3 py-1.5 text-sm transition-colors hover:bg-primary/15"
+                        className="flex items-center rounded-lg border border-primary/20 bg-primary/10 text-sm transition-colors hover:bg-primary/15"
                     >
-                        <span className="max-w-[150px] truncate font-medium">
+                        <button
+                            type="button"
+                            className="max-w-[174px] truncate rounded-l-lg py-1.5 pl-3 pr-2 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                            onClick={() => onChipClick(wallpaper.path)}
+                        >
                             {wallpaper.title}
-                        </span>
+                            <span className="sr-only">, locate in playlist</span>
+                        </button>
                         <Button
+                            type="button"
                             variant="ghost"
                             size="icon-sm"
-                            className="size-5 p-0 hover:bg-destructive/20 hover:text-destructive"
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                onRemove(wallpaper.path)
-                            }}
+                            aria-label={`Remove ${wallpaper.title} from playlist`}
+                            className="mr-1 size-6 p-0 hover:bg-destructive/20 hover:text-destructive"
+                            onClick={() => onRemove(wallpaper.path)}
                         >
                             <X className="size-3" />
                         </Button>

--- a/src/renderer/components/playlist/selected-chips.tsx
+++ b/src/renderer/components/playlist/selected-chips.tsx
@@ -26,11 +26,11 @@ export function SelectedChips({ wallpapers, onRemove, onChipClick }: SelectedChi
                         initial={{ opacity: 0, scale: 0.8 }}
                         animate={{ opacity: 1, scale: 1 }}
                         exit={{ opacity: 0, scale: 0.8 }}
-                        className="flex items-center rounded-lg border border-primary/20 bg-primary/10 text-sm transition-colors hover:bg-primary/15"
+                        className="flex items-center rounded-lg border border-primary/20 bg-primary/10 text-sm"
                     >
                         <button
                             type="button"
-                            className="max-w-[174px] truncate rounded-l-lg py-1.5 pl-3 pr-2 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                            className="max-w-[174px] truncate rounded-l-lg py-1.5 pl-3 pr-2 font-medium transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                             onClick={() => onChipClick(wallpaper.path)}
                         >
                             {wallpaper.title}

--- a/src/renderer/components/search-input.tsx
+++ b/src/renderer/components/search-input.tsx
@@ -2,6 +2,7 @@ import { Search, X } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
+import { useRef } from "react"
 
 interface SearchInputProps {
   placeholder?: string
@@ -17,12 +18,14 @@ export function SearchInput({
   setSearchQuery,
 }: SearchInputProps) {
   const glass = useGlass()
+  const inputRef = useRef<HTMLInputElement>(null)
 
   return (
     <div className={className}>
       <div className={cn("group relative flex-1 rounded-xl ring-1 ring-foreground/10 hover:ring-foreground/30 focus-within:ring-foreground/40 focus-within:shadow-sm", glass)}>
         <Search className="absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground/60 transition-colors duration-200 group-focus-within:text-foreground" />
         <Input
+          ref={inputRef}
           type="text"
           aria-label={placeholder}
           placeholder={placeholder}
@@ -35,7 +38,10 @@ export function SearchInput({
             type="button"
             aria-label="Clear search"
             className="absolute right-2 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => setSearchQuery("")}
+            onClick={() => {
+              setSearchQuery("")
+              requestAnimationFrame(() => inputRef.current?.focus())
+            }}
           >
             <X className="size-3" />
           </button>

--- a/src/renderer/components/search-input.tsx
+++ b/src/renderer/components/search-input.tsx
@@ -24,12 +24,22 @@ export function SearchInput({
         <Search className="absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground/60 transition-colors duration-200 group-focus-within:text-foreground" />
         <Input
           type="text"
+          aria-label={placeholder}
           placeholder={placeholder}
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
-          className="h-9 w-full rounded-xl border-0 bg-transparent pl-10 pr-4 text-sm font-medium tracking-wide text-foreground placeholder:text-muted-foreground/50 transition-all duration-200 focus:ring-0"
+          className="h-9 w-full rounded-xl border-0 bg-transparent pl-10 pr-10 text-sm font-medium tracking-wide text-foreground placeholder:text-muted-foreground/50 transition-all duration-200 focus:ring-0"
         />
-        {searchQuery && <X className="absolute right-3.5 top-1/2 size-3 -translate-y-1/2 text-muted-foreground cursor-pointer hover:text-foreground transition-colors" onClick={() => setSearchQuery("")} />}
+        {searchQuery && (
+          <button
+            type="button"
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => setSearchQuery("")}
+          >
+            <X className="size-3" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/components/settings/controls/setting-row-overlay.tsx
+++ b/src/renderer/components/settings/controls/setting-row-overlay.tsx
@@ -26,8 +26,10 @@ export function SettingRow({ label, children, disabled, changed, onClear, classN
                 {children}
                 {changed && onClear && !disabled && (
                     <button
+                        type="button"
+                        aria-label="Reset to global default"
                         onClick={onClear}
-                        className="text-muted-foreground hover:text-foreground transition-colors"
+                        className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         title="Reset to global default"
                     >
                         <X className="size-3.5" />

--- a/src/renderer/components/ui/pagination.tsx
+++ b/src/renderer/components/ui/pagination.tsx
@@ -40,7 +40,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 type PaginationLinkProps = {
   isActive?: boolean
 } & Partial<Pick<React.ComponentProps<typeof Button>, "size">> &
-  React.ComponentProps<"a">
+  React.ComponentProps<"button">
 
 function PaginationLink({
   className,
@@ -49,7 +49,8 @@ function PaginationLink({
   ...props
 }: PaginationLinkProps) {
   return (
-    <a
+    <button
+      type="button"
       aria-current={isActive ? "page" : undefined}
       data-slot="pagination-link"
       data-active={isActive}

--- a/src/renderer/components/ui/pagination.tsx
+++ b/src/renderer/components/ui/pagination.tsx
@@ -66,6 +66,21 @@ function PaginationLink({
   )
 }
 
+function PaginationCurrent({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-current="page"
+      data-slot="pagination-link"
+      data-active="true"
+      className={cn(buttonVariants({ variant: "outline", size: "icon" }), className)}
+      {...props}
+    />
+  )
+}
+
 function PaginationPrevious({
   className,
   ...props
@@ -149,6 +164,7 @@ export {
   Pagination,
   PaginationContent,
   PaginationLink,
+  PaginationCurrent,
   PaginationItem,
   PaginationPrevious,
   PaginationNext,

--- a/src/renderer/components/wallpaper/wallpaper-card.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-card.tsx
@@ -31,18 +31,14 @@ export const WallpaperCard = memo(function WallpaperCard({
 }: WallpaperCardProps) {
 
     return (
-        <button
-            type="button"
-            aria-pressed={selected}
-            aria-label={`${wallpaper.title}${selected ? ", selected" : ""}`}
+        <div
             className={cn(
-                "cv-auto group relative w-full overflow-hidden rounded-xl border bg-card text-left transition-all duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                "cv-auto group relative overflow-hidden rounded-xl border bg-card transition-all duration-200",
                 glassClassName,
                 selected
                     ? "!border-primary ring-2 ring-primary/20"
                     : "border-border hover:border-ring/50 hover:shadow-lg"
             )}
-            onClick={() => onClick?.(wallpaper)}
         >
             <WallpaperThumbnail
                 src={wallpaper.thumbnail}
@@ -64,9 +60,11 @@ export const WallpaperCard = memo(function WallpaperCard({
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <div className={cn(
-                                "absolute top-2 right-2 size-2.5 rounded-full ring-1 ring-black/20 ",
+                                "absolute top-2 right-2 z-20 size-2.5 rounded-full ring-1 ring-black/20",
                                 COMPATIBILITY_CONFIG[compatibilityStatus].bgColor
-                            )} />
+                            )}
+                                aria-hidden="true"
+                            />
                         </TooltipTrigger>
                         <TooltipContent side="top" className="text-xs">
                             {COMPATIBILITY_CONFIG[compatibilityStatus].label}
@@ -74,6 +72,12 @@ export const WallpaperCard = memo(function WallpaperCard({
                     </Tooltip>
                 )}
             </WallpaperThumbnail>
-        </button>
+            <button
+                type="button"
+                aria-label={`${wallpaper.title}${showCompatibilityDot && compatibilityStatus && compatibilityStatus !== "unknown" ? `, ${COMPATIBILITY_CONFIG[compatibilityStatus].label}` : ""}`}
+                className="absolute inset-0 z-10 cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                onClick={() => onClick?.(wallpaper)}
+            />
+        </div>
     )
 })

--- a/src/renderer/components/wallpaper/wallpaper-card.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-card.tsx
@@ -31,9 +31,12 @@ export const WallpaperCard = memo(function WallpaperCard({
 }: WallpaperCardProps) {
 
     return (
-        <div
+        <button
+            type="button"
+            aria-pressed={selected}
+            aria-label={`${wallpaper.title}${selected ? ", selected" : ""}`}
             className={cn(
-                "cv-auto group relative overflow-hidden rounded-xl border bg-card transition-all duration-200 cursor-pointer",
+                "cv-auto group relative w-full overflow-hidden rounded-xl border bg-card text-left transition-all duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 glassClassName,
                 selected
                     ? "!border-primary ring-2 ring-primary/20"
@@ -71,6 +74,6 @@ export const WallpaperCard = memo(function WallpaperCard({
                     </Tooltip>
                 )}
             </WallpaperThumbnail>
-        </div>
+        </button>
     )
 })

--- a/src/renderer/components/workshop/unsubscribe-button.tsx
+++ b/src/renderer/components/workshop/unsubscribe-button.tsx
@@ -17,6 +17,7 @@ export function UnsubscribeButton({ onClick, disabled = false }: UnsubscribeButt
                     className="shrink-0 hover:bg-destructive/10 hover:text-destructive"
                     onClick={onClick}
                     disabled={disabled}
+                    aria-label="Unsubscribe from wallpaper"
                 >
                     <Trash2 className="size-4" />
                 </Button>

--- a/src/renderer/components/workshop/workshop-pagination.tsx
+++ b/src/renderer/components/workshop/workshop-pagination.tsx
@@ -5,6 +5,7 @@ import {
   PaginationPrevious,
   PaginationNext,
   PaginationLink,
+  PaginationCurrent,
   PaginationEllipsis,
   getPaginationRange,
 } from "@/components/ui/pagination"
@@ -36,9 +37,8 @@ export function WorkshopPagination({
         <PaginationItem>
           <PaginationPrevious
             onClick={() => onPageChange(Math.max(page - 1, 1))}
-            aria-disabled={isPrevDisabled}
             disabled={isPrevDisabled}
-            className={isPrevDisabled ? "pointer-events-none opacity-50" : "cursor-pointer"}
+            className="cursor-pointer"
           />
         </PaginationItem>
         {showFirstPage && (
@@ -57,7 +57,7 @@ export function WorkshopPagination({
           </PaginationItem>
         ))}
         <PaginationItem>
-          <PaginationLink isActive aria-label={`Page ${page}, current page`} className="cursor-default">{page}</PaginationLink>
+          <PaginationCurrent aria-label={`Page ${page}, current page`}>{page}</PaginationCurrent>
         </PaginationItem>
         {nearbyPages.filter(p => p > page).map(p => (
           <PaginationItem key={p}>
@@ -77,9 +77,8 @@ export function WorkshopPagination({
         <PaginationItem>
           <PaginationNext
             onClick={() => onPageChange(page + 1)}
-            aria-disabled={isNextDisabled}
             disabled={isNextDisabled}
-            className={isNextDisabled ? "pointer-events-none opacity-50" : "cursor-pointer"}
+            className="cursor-pointer"
           />
         </PaginationItem>
       </PaginationContent>

--- a/src/renderer/components/workshop/workshop-pagination.tsx
+++ b/src/renderer/components/workshop/workshop-pagination.tsx
@@ -37,12 +37,13 @@ export function WorkshopPagination({
           <PaginationPrevious
             onClick={() => onPageChange(Math.max(page - 1, 1))}
             aria-disabled={isPrevDisabled}
+            disabled={isPrevDisabled}
             className={isPrevDisabled ? "pointer-events-none opacity-50" : "cursor-pointer"}
           />
         </PaginationItem>
         {showFirstPage && (
           <PaginationItem>
-            <PaginationLink onClick={() => onPageChange(1)} className="cursor-pointer">1</PaginationLink>
+            <PaginationLink aria-label="Go to page 1" onClick={() => onPageChange(1)} className="cursor-pointer">1</PaginationLink>
           </PaginationItem>
         )}
         {showStartEllipsis && (
@@ -52,15 +53,15 @@ export function WorkshopPagination({
         )}
         {nearbyPages.filter(p => p < page).map(p => (
           <PaginationItem key={p}>
-            <PaginationLink onClick={() => onPageChange(p)} className="cursor-pointer">{p}</PaginationLink>
+            <PaginationLink aria-label={`Go to page ${p}`} onClick={() => onPageChange(p)} className="cursor-pointer">{p}</PaginationLink>
           </PaginationItem>
         ))}
         <PaginationItem>
-          <PaginationLink isActive className="cursor-default">{page}</PaginationLink>
+          <PaginationLink isActive aria-label={`Page ${page}, current page`} className="cursor-default">{page}</PaginationLink>
         </PaginationItem>
         {nearbyPages.filter(p => p > page).map(p => (
           <PaginationItem key={p}>
-            <PaginationLink onClick={() => onPageChange(p)} className="cursor-pointer">{p}</PaginationLink>
+            <PaginationLink aria-label={`Go to page ${p}`} onClick={() => onPageChange(p)} className="cursor-pointer">{p}</PaginationLink>
           </PaginationItem>
         ))}
         {showEndEllipsis && (
@@ -70,13 +71,14 @@ export function WorkshopPagination({
         )}
         {showLastPage && (
           <PaginationItem>
-            <PaginationLink onClick={() => onPageChange(totalPages)} className="cursor-pointer">{totalPages}</PaginationLink>
+            <PaginationLink aria-label={`Go to page ${totalPages}`} onClick={() => onPageChange(totalPages)} className="cursor-pointer">{totalPages}</PaginationLink>
           </PaginationItem>
         )}
         <PaginationItem>
           <PaginationNext
             onClick={() => onPageChange(page + 1)}
             aria-disabled={isNextDisabled}
+            disabled={isNextDisabled}
             className={isNextDisabled ? "pointer-events-none opacity-50" : "cursor-pointer"}
           />
         </PaginationItem>

--- a/src/renderer/routes/displays.tsx
+++ b/src/renderer/routes/displays.tsx
@@ -152,9 +152,9 @@ function DisplaysPage() {
                             <TooltipProvider>
                                 <Tooltip>
                                     <TooltipTrigger asChild>
-                                        <div className="flex size-8 cursor-help items-center justify-center rounded-md text-muted-foreground ">
+                                        <button type="button" aria-label={`About wallpaper settings for ${monitor.name}`} className="flex size-8 cursor-help items-center justify-center rounded-md text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
                                             <Info className="size-4" />
-                                        </div>
+                                        </button>
                                     </TooltipTrigger>
                                     <TooltipContent side="left" className="max-w-xs">
                                         <p className="text-sm">

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -35,6 +35,8 @@ import * as z from "zod"
 const windowGeometrySchema = z.object({
     windowGeometry: z.string().trim().refine((value) => !value || /^[1-9]\d*x[1-9]\d*$/.test(value), "Use widthxheight, for example 800x600"),
 })
+const STARTUP_TRAY_CONTENT_ID = "startup-tray-options"
+const WINDOW_GEOMETRY_CONTENT_ID = "window-geometry-options"
 type WindowGeometryForm = z.infer<typeof windowGeometrySchema>
 
 export const Route = createFileRoute("/settings")({
@@ -140,31 +142,35 @@ function SettingsPage() {
                 >
                     <SettingRow label="Pause on fullscreen apps">
                         <Switch
+                            aria-label="Pause on fullscreen apps"
                             checked={settings.pauseOnFullscreen}
                             onCheckedChange={(checked) => updateSetting("pauseOnFullscreen", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Launch on startup">
                         <Switch
+                            aria-label="Launch on startup"
                             checked={settings.launchOnLogin}
                             onCheckedChange={(checked) => updateSetting("launchOnLogin", checked)}
                         />
                     </SettingRow>
-                    <SettingRow label={<span className="inline-flex items-center gap-1">Enable system tray <Button variant="ghost" size="icon" onClick={() => setStartupTrayOpen((o) => !o)} className="size-6 text-muted-foreground hover:text-foreground" title="Advanced tray options"><ChevronDown className={`size-3.5 transition-transform ${startupTrayOpen ? "rotate-180" : ""}`} /></Button></span>} className={!startupTrayOpen ? "border-b-0" : ""}>
+                    <SettingRow label={<span className="inline-flex items-center gap-1">Enable system tray <Button type="button" variant="ghost" size="icon" aria-label="Toggle advanced tray options" aria-expanded={startupTrayOpen} aria-controls={STARTUP_TRAY_CONTENT_ID} onClick={() => setStartupTrayOpen((o) => !o)} className="size-6 text-muted-foreground hover:text-foreground" title="Advanced tray options"><ChevronDown className={`size-3.5 transition-transform ${startupTrayOpen ? "rotate-180" : ""}`} /></Button></span>} className={!startupTrayOpen ? "border-b-0" : ""}>
                         <Switch
+                            aria-label="Enable system tray"
                             checked={settings.enableSystemTray}
                             onCheckedChange={(checked) => updateSetting("enableSystemTray", checked)}
                         />
                     </SettingRow>
                     {startupTrayOpen && (
                     <Collapsible open={startupTrayOpen} onOpenChange={setStartupTrayOpen}>
-                        <CollapsibleContent>
+                        <CollapsibleContent id={STARTUP_TRAY_CONTENT_ID}>
                             <div className="divide-y divide-border bg-muted/30">
                                 <SettingRow
                                     label="Minimize on startup"
                                     disabled={!settings.launchOnLogin || !settings.enableSystemTray}
                                 >
                                     <Switch
+                                        aria-label="Minimize on startup"
                                         checked={settings.minimizeOnStartup}
                                         onCheckedChange={(checked) => updateSetting("minimizeOnStartup", checked)}
                                     />
@@ -175,6 +181,7 @@ function SettingsPage() {
                                     className="border-b-0"
                                 >
                                     <Switch
+                                        aria-label="Minimize on close"
                                         checked={settings.minimizeOnClose}
                                         onCheckedChange={(checked) => updateSetting("minimizeOnClose", checked)}
                                     />
@@ -194,6 +201,7 @@ function SettingsPage() {
                     <CompatibilityScanRow settings={settings} updateSetting={updateSetting} />
                     <SettingRow label="Debug mode" >
                         <Switch
+                            aria-label="Debug mode"
                             checked={settings.debugMode}
                             onCheckedChange={(v) => updateSetting("debugMode", v)}
                         />
@@ -204,8 +212,12 @@ function SettingsPage() {
                             <span className="inline-flex items-center gap-1">
                                 Run in window mode
                                 <Button
+                                    type="button"
                                     variant="ghost"
                                     size="icon"
+                                    aria-label="Toggle window geometry options"
+                                    aria-expanded={windowGeometryOpen}
+                                    aria-controls={WINDOW_GEOMETRY_CONTENT_ID}
                                     onClick={() => setWindowGeometryOpen((o) => !o)}
                                     className="size-6 text-muted-foreground hover:text-foreground"
                                     title="Window geometry"
@@ -217,6 +229,7 @@ function SettingsPage() {
                         className={!windowGeometryOpen && !isFlatpakEnv ? "border-b-0" : ""}
                     >
                         <Switch
+                            aria-label="Run in window mode"
                             checked={settings.windowMode}
                             onCheckedChange={(v) => updateSetting("windowMode", v)}
                         />
@@ -224,7 +237,7 @@ function SettingsPage() {
 
                     {windowGeometryOpen && (
                         <Collapsible open={windowGeometryOpen} onOpenChange={setWindowGeometryOpen}>
-                            <CollapsibleContent>
+                            <CollapsibleContent id={WINDOW_GEOMETRY_CONTENT_ID}>
                                 <div className="bg-muted/30">
                                     <SettingRow
                                         label={(
@@ -242,6 +255,7 @@ function SettingsPage() {
                                                     placeholder="1920x1080"
                                                     disabled={!settings.windowMode}
                                                     aria-invalid={!!windowGeometryForm.formState.errors.windowGeometry}
+                                                    aria-label="Window size"
                                                     className="w-28"
                                                 />
                                                 <Button
@@ -249,6 +263,7 @@ function SettingsPage() {
                                                     size="icon"
                                                     type="submit"
                                                     disabled={!settings.windowMode || updateMutation.isPending}
+                                                    aria-label="Save window size"
                                                     title="Save window size"
                                                     className="bg-transparent"
                                                 >
@@ -270,6 +285,7 @@ function SettingsPage() {
                     {isFlatpakEnv && (
                         <SettingRow label="Bypass Flatpak sandbox" className="border-b-0">
                             <Switch
+                                aria-label="Bypass Flatpak sandbox"
                                 checked={settings.flatpakBypass}
                                 onCheckedChange={(v) => updateSetting("flatpakBypass", v)}
                             />
@@ -294,18 +310,21 @@ function SettingsPage() {
                     </SettingRow>
                     <SettingRow label="Mute audio">
                         <Switch
+                            aria-label="Mute audio"
                             checked={settings.silent}
                             onCheckedChange={(checked) => updateSetting("silent", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Don't mute when other apps play audio">
                         <Switch
+                            aria-label="Don't mute when other apps play audio"
                             checked={settings.noAutomute}
                             onCheckedChange={(checked) => updateSetting("noAutomute", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Audio reactive effects" className="border-b-0">
                         <Switch
+                            aria-label="Audio reactive effects"
                             checked={settings.audioProcessing}
                             onCheckedChange={(checked) => updateSetting("audioProcessing", checked)}
                         />
@@ -339,18 +358,21 @@ function SettingsPage() {
                     </SettingRow>
                     <SettingRow label="Disable mouse interaction">
                         <Switch
+                            aria-label="Disable mouse interaction"
                             checked={settings.disableMouse}
                             onCheckedChange={(checked) => updateSetting("disableMouse", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Disable parallax effect">
                         <Switch
+                            aria-label="Disable parallax effect"
                             checked={settings.disableParallax}
                             onCheckedChange={(checked) => updateSetting("disableParallax", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Disable particle effects" className="border-b-0">
                         <Switch
+                            aria-label="Disable particle effects"
                             checked={settings.disableParticles}
                             onCheckedChange={(checked) => updateSetting("disableParticles", checked)}
                         />
@@ -377,18 +399,21 @@ function SettingsPage() {
                     </SettingRow>
                     <SettingRow label="Show compatibility dot">
                         <Switch
+                            aria-label="Show compatibility dot"
                             checked={settings.showCompatibilityDot}
                             onCheckedChange={(checked) => updateSetting("showCompatibilityDot", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Show status bar">
                         <Switch
+                            aria-label="Show status bar"
                             checked={settings.showStatusBar}
                             onCheckedChange={(checked) => updateSetting("showStatusBar", checked)}
                         />
                     </SettingRow>
                     <SettingRow label="Dynamic background" className="border-b-0">
                         <Switch
+                            aria-label="Dynamic background"
                             checked={settings.dynamicBackground}
                             onCheckedChange={(checked) => updateSetting("dynamicBackground", checked)}
                         />

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -161,9 +161,8 @@ function SettingsPage() {
                             onCheckedChange={(checked) => updateSetting("enableSystemTray", checked)}
                         />
                     </SettingRow>
-                    {startupTrayOpen && (
                     <Collapsible open={startupTrayOpen} onOpenChange={setStartupTrayOpen}>
-                        <CollapsibleContent id={STARTUP_TRAY_CONTENT_ID}>
+                        <CollapsibleContent id={STARTUP_TRAY_CONTENT_ID} forceMount hidden={!startupTrayOpen}>
                             <div className="divide-y divide-border bg-muted/30">
                                 <SettingRow
                                     label="Minimize on startup"
@@ -189,7 +188,6 @@ function SettingsPage() {
                             </div>
                         </CollapsibleContent>
                     </Collapsible>
-                    )}
                 </SettingsSection>
 
                 {/* Compatibility Scan Section */}
@@ -235,10 +233,9 @@ function SettingsPage() {
                         />
                     </SettingRow>
 
-                    {windowGeometryOpen && (
-                        <Collapsible open={windowGeometryOpen} onOpenChange={setWindowGeometryOpen}>
-                            <CollapsibleContent id={WINDOW_GEOMETRY_CONTENT_ID}>
-                                <div className="bg-muted/30">
+                    <Collapsible open={windowGeometryOpen} onOpenChange={setWindowGeometryOpen}>
+                        <CollapsibleContent id={WINDOW_GEOMETRY_CONTENT_ID} forceMount hidden={!windowGeometryOpen}>
+                            <div className="bg-muted/30">
                                     <SettingRow
                                         label={(
                                             <span>
@@ -277,10 +274,9 @@ function SettingsPage() {
                                             )}
                                         </form>
                                     </SettingRow>
-                                </div>
-                            </CollapsibleContent>
-                        </Collapsible>
-                    )}
+                            </div>
+                        </CollapsibleContent>
+                    </Collapsible>
 
                     {isFlatpakEnv && (
                         <SettingRow label="Bypass Flatpak sandbox" className="border-b-0">


### PR DESCRIPTION
Part 1 of the keyboard-only workflow stack.

What changed
- adds a skip-to-content link and focusable main target
- converts wallpaper cards, search clearing, selected chips, pagination, and tooltip affordances into semantic keyboard controls
- labels icon-only actions and settings switches
- exposes collapsible state with aria-expanded and aria-controls
- strengthens visible focus behavior and removes hidden controls from the tab order

Verification
- TypeScript 5.9: tsc --noEmit passes
- git diff --check passes

Stack
- This PR targets main
- Next: #105
- Final: #106