### PR TITLE
Keyboard navigation 2/3: roving wallpaper grids

### DIFF
--- a/src/renderer/components/playlist/playlist-editor-grid.tsx
+++ b/src/renderer/components/playlist/playlist-editor-grid.tsx
@@ -172,6 +172,7 @@ export function PlaylistEditorGrid({ editPlaylist }: PlaylistEditorGridProps) {
                 compatibilityMap={compatibilityMap}
                 showCompatibilityDot={appSettings?.showCompatibilityDot ?? true}
                 isSelected={(w) => editor.selectedSet.has(w.path)}
+                selectionMode="pressed"
                 onCardClick={editor.handleToggleWallpaper}
                 emptyMessage="No wallpapers found"
                 emptySubMessage={searchQuery ? "Try a different search term" : "Install wallpapers first"}

--- a/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
+++ b/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react"
+import { useEffect, type ReactNode } from "react"
 import { X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -18,6 +18,16 @@ interface WallpaperDetailsShellProps {
 export function WallpaperDetailsShell({ wallpaper, onClose, actions, children }: WallpaperDetailsShellProps) {
     const glass = useGlass()
 
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== "Escape" || document.querySelector('[role="dialog"][data-state="open"]')) return
+            onClose()
+        }
+
+        document.addEventListener("keydown", handleKeyDown)
+        return () => document.removeEventListener("keydown", handleKeyDown)
+    }, [onClose])
+
     return (
         <div id="wallpaper-details" className={cn("sticky top-0 max-h-[calc(100vh_-_var(--status-bar-h,0rem)_-_2rem)] w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-card scrollbar-thin", glass)}>
             <div className="sticky top-2 z-10 flex justify-end pr-2 h-0">
@@ -26,6 +36,7 @@ export function WallpaperDetailsShell({ wallpaper, onClose, actions, children }:
                     size="icon-sm"
                     className="size-7 bg-black/50 text-white hover:bg-black/70"
                     onClick={onClose}
+                    aria-label={`Close details for ${wallpaper.title}`}
                 >
                     <X className="size-4" />
                 </Button>

--- a/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
@@ -1,4 +1,4 @@
-import { useImperativeHandle, useLayoutEffect, useRef, useState, type ReactNode, type Ref } from "react"
+import { useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState, type ReactNode, type Ref } from "react"
 import { FolderOpen, type LucideIcon } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -8,6 +8,7 @@ import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
 import { findScrollParent, DEFAULT_GRID_COLS, columnsForWidth } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
+import { useWallpaperGridNavigation } from "@/hooks/use-wallpaper-grid-navigation"
 
 const GAP = 16 // matches gap-4 (1rem)
 const OVERSCAN = 3 // rows rendered beyond the viewport to smooth scrolling
@@ -29,6 +30,7 @@ interface VirtualizedWallpaperGridProps {
     emptyMessage?: string
     emptySubMessage?: string
     renderCardOverlay?: (wallpaper: Wallpaper) => ReactNode
+    selectionMode?: "expanded" | "pressed"
     ref?: Ref<VirtualizedWallpaperGridHandle>
 }
 
@@ -46,6 +48,7 @@ export function VirtualizedWallpaperGrid({
     emptyMessage = "No wallpapers found",
     emptySubMessage,
     renderCardOverlay,
+    selectionMode = "expanded",
     ref,
 }: VirtualizedWallpaperGridProps) {
     const parentRef = useRef<HTMLDivElement>(null)
@@ -55,6 +58,10 @@ export function VirtualizedWallpaperGrid({
     const [width, setWidth] = useState(0)
     const [viewportHeight, setViewportHeight] = useState(0)
     const [scrollMargin, setScrollMargin] = useState(0)
+    const itemIds = useMemo(
+        () => wallpapers.map(wallpaper => wallpaper.path ?? wallpaper.id),
+        [wallpapers],
+    )
 
     // Resolve the scroll container once mounted.
     useLayoutEffect(() => {
@@ -101,6 +108,18 @@ export function VirtualizedWallpaperGrid({
         overscan: OVERSCAN,
         scrollMargin,
     })
+    const handleNavigate = useCallback((index: number) => {
+        if (columns === 0) return
+        virtualizer.scrollToIndex(Math.floor(index / columns), {
+            align: "auto",
+            behavior: "auto",
+        })
+    }, [columns, virtualizer])
+    const { focusId, getItemProps } = useWallpaperGridNavigation({
+        itemIds,
+        columns,
+        onNavigate: handleNavigate,
+    })
 
     // Re-measure rows when geometry changes (column count / width).
     useLayoutEffect(() => {
@@ -109,14 +128,9 @@ export function VirtualizedWallpaperGrid({
 
     useImperativeHandle(ref, () => ({
         scrollToPath: (path: string) => {
-            const index = wallpapers.findIndex(w => w.path === path)
-            if (index < 0 || columns === 0) return
-            virtualizer.scrollToIndex(Math.floor(index / columns), {
-                align: "center",
-                behavior: "auto",
-            })
+            focusId(path)
         },
-    }), [virtualizer, wallpapers, columns])
+    }), [focusId])
 
     const skeleton = (
         <div className={`grid gap-4 ${DEFAULT_GRID_COLS}`}>
@@ -127,13 +141,15 @@ export function VirtualizedWallpaperGrid({
     )
 
     const rows = (
-        <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+        <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
             {virtualizer.getVirtualItems().map((virtualRow) => {
                 const start = virtualRow.index * columns
                 const rowItems = wallpapers.slice(start, start + columns)
                 return (
                     <div
                         key={virtualRow.key}
+                        role="row"
+                        aria-rowindex={virtualRow.index + 1}
                         data-index={virtualRow.index}
                         ref={virtualizer.measureElement}
                         className="grid gap-4"
@@ -147,8 +163,20 @@ export function VirtualizedWallpaperGrid({
                             paddingBottom: GAP,
                         }}
                     >
-                        {rowItems.map((wallpaper) => (
-                            <div key={wallpaper.id} className="relative" data-wallpaper-path={wallpaper.path}>
+                        {rowItems.map((wallpaper, columnIndex) => {
+                            const index = start + columnIndex
+                            const id = itemIds[index]
+                            const itemProps = getItemProps(id, index)
+
+                            return (
+                            <div
+                                key={wallpaper.id}
+                                role="gridcell"
+                                aria-rowindex={virtualRow.index + 1}
+                                aria-colindex={columnIndex + 1}
+                                className="relative"
+                                data-wallpaper-path={wallpaper.path}
+                            >
                                 <WallpaperCard
                                     wallpaper={wallpaper}
                                     selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
@@ -156,10 +184,13 @@ export function VirtualizedWallpaperGrid({
                                     compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
                                     showCompatibilityDot={showCompatibilityDot}
                                     glassClassName={glass}
+                                    selectionMode={selectionMode}
+                                    {...itemProps}
                                 />
                                 {renderCardOverlay?.(wallpaper)}
                             </div>
-                        ))}
+                            )
+                        })}
                     </div>
                 )
             })}
@@ -169,7 +200,14 @@ export function VirtualizedWallpaperGrid({
     // The parentRef div is now always mounted so the layout effects above can
     // resolve the scroll parent and attach the ResizeObserver on first mount.
     return (
-        <div ref={parentRef}>
+        <div
+            ref={parentRef}
+            role={isLoading || wallpapers.length === 0 ? undefined : "grid"}
+            aria-label="Wallpapers"
+            aria-busy={isLoading}
+            aria-rowcount={isLoading ? undefined : rowCount}
+            aria-colcount={isLoading ? undefined : columns}
+        >
             {isLoading ? (
                 skeleton
             ) : wallpapers.length === 0 ? (

--- a/src/renderer/components/wallpaper/wallpaper-card.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-card.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react"
+import { memo, type FocusEventHandler, type KeyboardEventHandler, type Ref } from "react"
 import { cn } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { WallpaperThumbnail } from "./wallpaper-thumbnail"
@@ -18,6 +18,11 @@ interface WallpaperCardProps {
      * a grid of cards costs zero extra queries per item.
      */
     glassClassName?: string
+    tabIndex?: number
+    buttonRef?: Ref<HTMLButtonElement>
+    onFocus?: FocusEventHandler<HTMLButtonElement>
+    onKeyDown?: KeyboardEventHandler<HTMLButtonElement>
+    selectionMode?: "expanded" | "pressed"
 }
 
 
@@ -28,6 +33,11 @@ export const WallpaperCard = memo(function WallpaperCard({
     compatibilityStatus,
     showCompatibilityDot = true,
     glassClassName,
+    tabIndex,
+    buttonRef,
+    onFocus,
+    onKeyDown,
+    selectionMode = "expanded",
 }: WallpaperCardProps) {
 
     return (
@@ -73,8 +83,14 @@ export const WallpaperCard = memo(function WallpaperCard({
                 )}
             </WallpaperThumbnail>
             <button
+                ref={buttonRef}
                 type="button"
+                tabIndex={tabIndex}
+                aria-expanded={selectionMode === "expanded" ? selected : undefined}
+                aria-pressed={selectionMode === "pressed" ? selected : undefined}
                 aria-label={`${wallpaper.title}${showCompatibilityDot && compatibilityStatus && compatibilityStatus !== "unknown" ? `, ${COMPATIBILITY_CONFIG[compatibilityStatus].label}` : ""}`}
+                onFocus={onFocus}
+                onKeyDown={onKeyDown}
                 className="absolute inset-0 z-10 cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 onClick={() => onClick?.(wallpaper)}
             />

--- a/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react"
+import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { FolderOpen, type LucideIcon } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { EmptyState } from "@/components/empty-state"
@@ -7,6 +7,8 @@ import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
 import { DEFAULT_GRID_COLS } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
+import { useWallpaperGridNavigation } from "@/hooks/use-wallpaper-grid-navigation"
+import { cn } from "@/lib/utils"
 
 const SKELETON_COUNT = 12
 
@@ -40,8 +42,31 @@ export function WallpaperGridLayout({
     gridClassName,
 }: WallpaperGridLayoutProps) {
     const gridCols = DEFAULT_GRID_COLS
+    const gridRef = useRef<HTMLDivElement>(null)
+    const [columns, setColumns] = useState(1)
     // Resolved once for the whole grid — cards must not subscribe individually.
     const glass = useGlass()
+    const itemIds = useMemo(
+        () => wallpapers.map(wallpaper => wallpaper.path ?? wallpaper.id),
+        [wallpapers],
+    )
+    const rowCount = Math.ceil(wallpapers.length / columns)
+    const { getItemProps } = useWallpaperGridNavigation({ itemIds, columns })
+
+    useLayoutEffect(() => {
+        const node = gridRef.current
+        if (!node) return
+
+        const measure = () => {
+            const template = getComputedStyle(node).gridTemplateColumns
+            setColumns(Math.max(1, template.split(" ").filter(Boolean).length))
+        }
+
+        measure()
+        const observer = new ResizeObserver(measure)
+        observer.observe(node)
+        return () => observer.disconnect()
+    }, [])
 
     if (isLoading) {
         return (
@@ -58,18 +83,44 @@ export function WallpaperGridLayout({
     }
 
     return (
-        <div className={`grid gap-4 ${gridCols}`}>
-            {wallpapers.map((wallpaper) => (
-                <div key={wallpaper.id} className="relative" data-wallpaper-path={wallpaper.path}>
-                    <WallpaperCard
-                        wallpaper={wallpaper}
-                        selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
-                        onClick={onCardClick}
-                        compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
-                        showCompatibilityDot={showCompatibilityDot}
-                        glassClassName={glass}
-                    />
-                    {renderCardOverlay?.(wallpaper)}
+        <div
+            ref={gridRef}
+            role="grid"
+            aria-label="Wallpapers"
+            aria-rowcount={rowCount}
+            aria-colcount={columns}
+            className={cn("grid gap-4", gridClassName ?? gridCols)}
+        >
+            {Array.from({ length: rowCount }, (_, rowIndex) => (
+                <div key={rowIndex} role="row" className="contents">
+                    {wallpapers.slice(rowIndex * columns, (rowIndex + 1) * columns).map((wallpaper, columnIndex) => {
+                        const index = rowIndex * columns + columnIndex
+                        const id = itemIds[index]
+                        const itemProps = getItemProps(id, index)
+
+                        return (
+                            <div
+                                key={wallpaper.id}
+                                role="gridcell"
+                                aria-rowindex={rowIndex + 1}
+                                aria-colindex={columnIndex + 1}
+                                className="relative"
+                                data-wallpaper-path={wallpaper.path}
+                                data-wallpaper-id={wallpaper.id}
+                            >
+                                <WallpaperCard
+                                    wallpaper={wallpaper}
+                                    selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
+                                    onClick={onCardClick}
+                                    compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                                    showCompatibilityDot={showCompatibilityDot}
+                                    glassClassName={glass}
+                                    {...itemProps}
+                                />
+                                {renderCardOverlay?.(wallpaper)}
+                            </div>
+                        )
+                    })}
                 </div>
             ))}
         </div>

--- a/src/renderer/components/wallpaper/wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid.tsx
@@ -2,14 +2,14 @@ import { motion, AnimatePresence } from "framer-motion"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { type Wallpaper } from "./wallpaper-card"
 import { GridHeader } from "./wallpaper-grid-header"
-import { VirtualizedWallpaperGrid } from "./virtualized-wallpaper-grid"
+import { VirtualizedWallpaperGrid, type VirtualizedWallpaperGridHandle } from "./virtualized-wallpaper-grid"
 import { AlertCircle, FolderOpen } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWallpaperSearch } from "@/contexts/wallpaper-search-context"
 import { useWallpaperBackground } from "@/contexts/wallpaper-background-context"
 import { useWallpapers, filterAndSortWallpapers } from "@/hooks/use-wallpapers"
 import { useWallpaperSelection } from "@/hooks/use-wallpaper-selection"
-import { useMemo, useEffect, lazy, Suspense } from "react"
+import { useMemo, useEffect, useCallback, useRef, lazy, Suspense } from "react"
 import { useAtomValue } from "jotai"
 import { unsubscribedWorkshopIdsAtom } from "@/contexts/atoms/workshop-atoms"
 
@@ -17,6 +17,7 @@ const WallpaperDetails = lazy(() => import("./details-card/wallpaper-details").t
 
 // TODO: Fix wallpaper details size so that is consistent width with a column
 export function WallpaperGrid() {
+    const gridRef = useRef<VirtualizedWallpaperGridHandle>(null)
     const { selectedWallpaper, setSelectedWallpaper, toggleWallpaper } = useWallpaperSelection()
     const unsubscribedWorkshopIds = useAtomValue(unsubscribedWorkshopIdsAtom)
     const { searchQuery, filterType, filterAgeRating, filterTags, filterResolution, sortBy, sortOrder, setAvailableTags, setAvailableResolutions, filterCompatibility } = useWallpaperSearch()
@@ -118,6 +119,12 @@ export function WallpaperGrid() {
         setSelectedWallpaper(null)
     }
 
+    const handleCloseDetails = useCallback(() => {
+        const path = selectedWallpaper?.path ?? selectedWallpaper?.id
+        setSelectedWallpaper(null)
+        if (path) requestAnimationFrame(() => gridRef.current?.scrollToPath(path))
+    }, [selectedWallpaper, setSelectedWallpaper])
+
     // Error state
     if (error) {
         return (
@@ -144,6 +151,7 @@ export function WallpaperGrid() {
             <div className="flex items-start gap-6 flex-1">
                 <div className="flex-1 h-fit transition-all duration-300">
                     <VirtualizedWallpaperGrid
+                        ref={gridRef}
                         wallpapers={wallpapers}
                         isLoading={isLoading}
                         compatibilityMap={compatibilityMap}
@@ -174,7 +182,7 @@ export function WallpaperGrid() {
                                 <WallpaperDetails
                                     key={selectedWallpaper.id}
                                     wallpaper={selectedWallpaper}
-                                    onClose={() => setSelectedWallpaper(null)}
+                                    onClose={handleCloseDetails}
                                     onUnsubscribe={handleUnsubscribe}
                                 />
                             </Suspense>

--- a/src/renderer/components/workshop/workshop-discover-view.tsx
+++ b/src/renderer/components/workshop/workshop-discover-view.tsx
@@ -6,6 +6,7 @@ import { WorkshopConnectionPrompt } from "@/components/workshop/workshop-connect
 import { WorkshopDiscoverSection } from "@/components/workshop/workshop-discover-section"
 import { WorkshopPagination } from "@/components/workshop/workshop-pagination"
 import { IconButton } from "@/components/ui/icon-button"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { trpc } from "@/lib/trpc"
 import { cn, toWallpaper } from "@/lib/utils"
@@ -246,9 +247,15 @@ export function WorkshopDiscoverView({
 
       {hasMore && (
         <div ref={loadMoreRef} className="flex justify-center py-2">
-          <div className={cn(glass, "rounded-full px-4 py-2 text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground")}>
-            Loading more categories
-          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(glass, "rounded-full px-4 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground")}
+            onClick={() => setVisibleSectionCount(current => Math.min(current + DISCOVER_SECTION_BATCH_SIZE, sections.length))}
+          >
+            Load more categories
+          </Button>
         </div>
       )}
     </div>

--- a/src/renderer/hooks/use-wallpaper-grid-navigation.ts
+++ b/src/renderer/hooks/use-wallpaper-grid-navigation.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type RefCallback } from "react"
+
+interface WallpaperGridNavigationOptions {
+    itemIds: string[]
+    columns: number
+    onNavigate?: (index: number) => void
+}
+
+interface WallpaperGridItemProps {
+    tabIndex: number
+    buttonRef: RefCallback<HTMLButtonElement>
+    onFocus: () => void
+    onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void
+}
+
+export function useWallpaperGridNavigation({
+    itemIds,
+    columns,
+    onNavigate,
+}: WallpaperGridNavigationOptions) {
+    const itemRefs = useRef(new Map<string, HTMLButtonElement>())
+    const lastIndexRef = useRef(0)
+    const [activeId, setActiveId] = useState<string | null>(itemIds[0] ?? null)
+    const idToIndex = useMemo(
+        () => new Map(itemIds.map((id, index) => [id, index])),
+        [itemIds],
+    )
+
+    useEffect(() => {
+        if (activeId && idToIndex.has(activeId)) return
+
+        const nextIndex = Math.min(lastIndexRef.current, itemIds.length - 1)
+        setActiveId(nextIndex >= 0 ? itemIds[nextIndex] : null)
+    }, [activeId, idToIndex, itemIds])
+
+    const focusIndex = useCallback((index: number) => {
+        const nextIndex = Math.max(0, Math.min(index, itemIds.length - 1))
+        const nextId = itemIds[nextIndex]
+        if (!nextId) return
+
+        lastIndexRef.current = nextIndex
+        setActiveId(nextId)
+        onNavigate?.(nextIndex)
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => itemRefs.current.get(nextId)?.focus())
+        })
+    }, [itemIds, onNavigate])
+
+    const focusId = useCallback((id: string) => {
+        const index = idToIndex.get(id)
+        if (index === undefined) return
+        focusIndex(index)
+    }, [focusIndex, idToIndex])
+
+    const getItemProps = useCallback((id: string, index: number): WallpaperGridItemProps => ({
+        tabIndex: activeId === id ? 0 : -1,
+        buttonRef: (node) => {
+            if (node) itemRefs.current.set(id, node)
+            else itemRefs.current.delete(id)
+        },
+        onFocus: () => {
+            lastIndexRef.current = index
+            setActiveId(id)
+        },
+        onKeyDown: (event) => {
+            const rowStart = Math.floor(index / columns) * columns
+            const rowEnd = Math.min(rowStart + columns - 1, itemIds.length - 1)
+            let nextIndex = index
+
+            if (event.key === "ArrowLeft" && index > rowStart) nextIndex = index - 1
+            else if (event.key === "ArrowRight" && index < rowEnd) nextIndex = index + 1
+            else if (event.key === "ArrowUp" && index >= columns) nextIndex = index - columns
+            else if (event.key === "ArrowDown" && index + columns < itemIds.length) nextIndex = index + columns
+            else if (event.key === "Home") nextIndex = event.metaKey || event.ctrlKey ? 0 : rowStart
+            else if (event.key === "End") nextIndex = event.metaKey || event.ctrlKey ? itemIds.length - 1 : rowEnd
+            else return
+
+            event.preventDefault()
+            if (nextIndex === index) return
+            focusIndex(nextIndex)
+        },
+    }), [activeId, columns, focusIndex, itemIds.length])
+
+    return { activeId, focusId, getItemProps }
+}

--- a/src/renderer/routes/workshop.tsx
+++ b/src/renderer/routes/workshop.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useAtom } from "jotai"
 import { PageHeader } from "@/components/page-header"
 import { WorkshopToolbar } from "@/components/workshop/workshop-toolbar"
@@ -75,6 +75,16 @@ function WorkshopPage() {
     }
   }
 
+  const handleCloseDetails = useCallback(() => {
+    const wallpaperId = selectedWallpaper?.id
+    setSelectedWallpaper(null)
+    if (!wallpaperId) return
+
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLButtonElement>(`[data-wallpaper-id="${CSS.escape(wallpaperId)}"] button`)?.focus()
+    })
+  }, [selectedWallpaper, setSelectedWallpaper])
+
   return (
     <div className="flex flex-col h-full p-6">
       <PageHeader
@@ -113,7 +123,7 @@ function WorkshopPage() {
 
         <WorkshopDetailsPanel
           wallpaper={selectedWallpaper}
-          onClose={() => setSelectedWallpaper(null)}
+          onClose={handleCloseDetails}
           onExitComplete={() => {
             // Only collapse columns when the panel is fully gone. When switching
             // between cards the exit fires too, but a selection still exists.


### PR DESCRIPTION
Part 2 of the keyboard-only workflow stack. Depends on #104.

What changed
- adds a shared roving-tabindex navigation hook for regular and virtualized wallpaper grids
- supports Arrow keys, Home/End, and Mod+Home/End with O(1) index movement
- restores the nearest valid focus after filtering and focuses virtualized cards after scrolling
- adds ARIA grid, row, cell, count, and index metadata
- distinguishes expanded detail cards from pressed playlist selections
- restores card focus after closing details with Escape
- adds a keyboard-operable Load more categories fallback

Verification
- TypeScript 5.9: tsc --noEmit passes
- git diff --check passes

Stack
- Previous: #104
- This PR targets keyboard-navigation/semantics
- Next: #106