### PR TITLE
Keyboard navigation 3/3: app shortcuts and key hints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-form": "^1.28.3",
+        "@tanstack/react-hotkeys": "0.10.0",
         "@tanstack/react-query": "^5.90.17",
         "@tanstack/react-router": "^1.147.2",
         "@tanstack/react-virtual": "^3.14.2",
@@ -608,11 +609,15 @@
 
     "@tanstack/history": ["@tanstack/history@1.145.7", "", {}, "sha512-gMo/ReTUp0a3IOcZoI3hH6PLDC2R/5ELQ7P2yu9F6aEkA0wSQh+Q4qzMrtcKvF2ut0oE+16xWCGDo/TdYd6cEQ=="],
 
+    "@tanstack/hotkeys": ["@tanstack/hotkeys@0.8.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA=="],
+
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.1.1", "", {}, "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.17", "", {}, "sha512-hDww+RyyYhjhUfoYQ4es6pbgxY7LNiPWxt4l1nJqhByjndxJ7HIjDxTBtfvMr5HwjYavMrd+ids5g4Rfev3lVQ=="],
 
     "@tanstack/react-form": ["@tanstack/react-form@1.28.3", "", { "dependencies": { "@tanstack/form-core": "1.28.3", "@tanstack/react-store": "^0.8.1" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-84yd0swZRcyC3Q46dYBH6bHf1tlIY1flchbdG3VwArg/wLVW5RdBenIrJhleHjk2OxXuF+9HoKQbHglJyWIXQA=="],
+
+    "@tanstack/react-hotkeys": ["@tanstack/react-hotkeys@0.10.0", "", { "dependencies": { "@tanstack/hotkeys": "0.8.0", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.17", "", { "dependencies": { "@tanstack/query-core": "5.90.17" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-PGc2u9KLwohDUSchjW9MZqeDQJfJDON7y4W7REdNBgiFKxQy+Pf7eGjiFWEj5xPqKzAeHYdAb62IWI1a9UJyGQ=="],
 
@@ -2494,6 +2499,10 @@
 
     "@tanstack/form-core/@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
 
+    "@tanstack/hotkeys/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
+
+    "@tanstack/react-hotkeys/@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
+
     "@tanstack/react-router/@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
 
     "@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
@@ -2947,6 +2956,8 @@
     "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
 
     "@radix-ui/react-toolbar/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
+
+    "@tanstack/react-hotkeys/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
 
     "@types/cacheable-request/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-form": "^1.28.3",
+    "@tanstack/react-hotkeys": "0.10.0",
     "@tanstack/react-query": "^5.90.17",
     "@tanstack/react-router": "^1.147.2",
     "@tanstack/react-virtual": "^3.14.2",

--- a/src/renderer/components/app-keyboard-shortcuts.tsx
+++ b/src/renderer/components/app-keyboard-shortcuts.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { KeyboardShortcut } from "@/components/keyboard-shortcut"
+import { getAriaKeyShortcut, KEYBOARD_SHORTCUTS, type KeyboardShortcutId } from "@/lib/keyboard-shortcuts"
+import { Button } from "@/components/ui/button"
+import { Keyboard } from "lucide-react"
+
+const NAVIGATION_SHORTCUTS = [
+    ["installed", "/"],
+    ["workshop", "/workshop"],
+    ["playlists", "/playlists"],
+    ["displays", "/displays"],
+    ["settings", "/settings"],
+] as const satisfies ReadonlyArray<readonly [KeyboardShortcutId, string]>
+
+const HELP_SHORTCUTS = Object.entries(KEYBOARD_SHORTCUTS) as Array<
+    [KeyboardShortcutId, (typeof KEYBOARD_SHORTCUTS)[KeyboardShortcutId]]
+>
+
+export function AppKeyboardShortcuts() {
+    const navigate = useNavigate()
+    const [helpOpen, setHelpOpen] = useState(false)
+    const definitions = useMemo<UseHotkeyDefinition[]>(() => {
+        const search = KEYBOARD_SHORTCUTS.search
+        const focusSearch = () => {
+            const input = document.querySelector<HTMLInputElement>("[data-shortcut-search]")
+            input?.focus()
+            input?.select()
+        }
+
+        return [
+            {
+                hotkey: search.hotkey,
+                callback: focusSearch,
+                options: { ignoreInputs: false, meta: { name: search.label, description: search.description } },
+            },
+            ...search.alternateHotkeys.map(hotkey => ({
+                hotkey,
+                callback: focusSearch,
+                options: { ignoreInputs: false, meta: { name: search.label, description: search.description } },
+            })),
+            ...NAVIGATION_SHORTCUTS.map(([id, to]) => ({
+                hotkey: KEYBOARD_SHORTCUTS[id].hotkey,
+                callback: () => navigate({ to }),
+                options: {
+                    ignoreInputs: false,
+                    meta: { name: KEYBOARD_SHORTCUTS[id].label, description: KEYBOARD_SHORTCUTS[id].description },
+                },
+            })),
+            {
+                hotkey: KEYBOARD_SHORTCUTS.help.hotkey,
+                callback: () => setHelpOpen(true),
+                options: {
+                    ignoreInputs: true,
+                    meta: { name: KEYBOARD_SHORTCUTS.help.label, description: KEYBOARD_SHORTCUTS.help.description },
+                },
+            },
+        ]
+    }, [navigate])
+
+    useHotkeys(definitions, {
+        conflictBehavior: "replace",
+        preventDefault: true,
+        stopPropagation: true,
+    })
+
+    return (
+        <Dialog open={helpOpen} onOpenChange={setHelpOpen}>
+            <DialogTrigger asChild>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-keyshortcuts={getAriaKeyShortcut("help")}
+                    className="mb-2 w-full justify-start text-muted-foreground"
+                >
+                    <Keyboard className="size-4" />
+                    Shortcuts
+                    <KeyboardShortcut shortcut="help" className="ml-auto" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="max-h-[min(42rem,85vh)] overflow-y-auto sm:max-w-xl">
+                <DialogHeader>
+                    <DialogTitle>Keyboard shortcuts</DialogTitle>
+                    <DialogDescription>Navigate, search, and manage wallpapers without leaving the keyboard.</DialogDescription>
+                </DialogHeader>
+                <div className="divide-y divide-border">
+                    {HELP_SHORTCUTS.map(([id, shortcut]) => (
+                        <div key={id} className="flex items-center justify-between gap-6 py-3 first:pt-0 last:pb-0">
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium">{shortcut.label}</p>
+                                <p className="text-xs text-muted-foreground">{shortcut.description}</p>
+                            </div>
+                            <KeyboardShortcut shortcut={id} />
+                        </div>
+                    ))}
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/renderer/components/error-message.tsx
+++ b/src/renderer/components/error-message.tsx
@@ -51,7 +51,7 @@ export const ErrorMessage = ({
       <button
         type="button"
         onClick={() => setMessage(null)}
-        className="opacity-0 transition-opacity duration-200 group-hover:opacity-100 hover:text-destructive/80"
+        className="rounded-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 hover:text-destructive/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         aria-label="Close error message"
       >
         <X className="h-4 w-4" />

--- a/src/renderer/components/keyboard-shortcut.tsx
+++ b/src/renderer/components/keyboard-shortcut.tsx
@@ -1,0 +1,20 @@
+import { formatForDisplay } from "@tanstack/react-hotkeys"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { KEYBOARD_SHORTCUTS, type KeyboardShortcutId } from "@/lib/keyboard-shortcuts"
+import { cn } from "@/lib/utils"
+
+interface KeyboardShortcutProps {
+    shortcut: KeyboardShortcutId
+    className?: string
+}
+
+export function KeyboardShortcut({ shortcut, className }: KeyboardShortcutProps) {
+    const display = formatForDisplay(KEYBOARD_SHORTCUTS[shortcut].hotkey)
+    const keys = display.split(/\s*\+\s*|\s+/).filter(Boolean)
+
+    return (
+        <KbdGroup className={cn("shrink-0", className)} aria-hidden="true">
+            {keys.map(key => <Kbd key={key}>{key}</Kbd>)}
+        </KbdGroup>
+    )
+}

--- a/src/renderer/components/layout/side-bar.tsx
+++ b/src/renderer/components/layout/side-bar.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router"
+import type { ElementType } from "react"
 import {
     Download,
     ListVideo,
@@ -20,14 +21,17 @@ import {
 } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
 import { useTheme } from "../theme-provider"
+import { KeyboardShortcut } from "@/components/keyboard-shortcut"
+import { getAriaKeyShortcut, type KeyboardShortcutId } from "@/lib/keyboard-shortcuts"
+import { AppKeyboardShortcuts } from "@/components/app-keyboard-shortcuts"
 
 const navItems = [
-    { to: "/", icon: Download, label: "Installed" },
-    { to: "/workshop", icon: SteamIcon, label: "Workshop" },
-    { to: "/playlists", icon: ListVideo, label: "Playlists" },
-    { to: "/displays", icon: Monitor, label: "Displays" },
-    { to: "/settings", icon: Settings, label: "Settings" },
-] as const
+    { to: "/", icon: Download, label: "Installed", shortcut: "installed" },
+    { to: "/workshop", icon: SteamIcon, label: "Workshop", shortcut: "workshop" },
+    { to: "/playlists", icon: ListVideo, label: "Playlists", shortcut: "playlists" },
+    { to: "/displays", icon: Monitor, label: "Displays", shortcut: "displays" },
+    { to: "/settings", icon: Settings, label: "Settings", shortcut: "settings" },
+] as const satisfies ReadonlyArray<{ to: string, icon: ElementType, label: string, shortcut: KeyboardShortcutId }>
 
 interface SidebarProps {
     className?: string
@@ -60,9 +64,10 @@ export function Sidebar({ className }: SidebarProps) {
                                 const isActive = currentPath === item.to
                                 return (
                                     <SidebarMenuItem key={item.to}>
-                                        <SidebarMenuButton isActive={isActive} tooltip={item.label} onClick={() => navigate({ to: item.to })}>
+                                        <SidebarMenuButton aria-keyshortcuts={getAriaKeyShortcut(item.shortcut)} isActive={isActive} tooltip={item.label} onClick={() => navigate({ to: item.to })}>
                                             <item.icon className="size-4" />
                                             <span>{item.label}</span>
+                                            <KeyboardShortcut shortcut={item.shortcut} className="ml-auto group-data-[collapsible=icon]:hidden" />
                                         </SidebarMenuButton>
                                     </SidebarMenuItem>
                                 )
@@ -74,6 +79,7 @@ export function Sidebar({ className }: SidebarProps) {
 
             <SidebarFooter className="group-data-[collapsible=icon]:hidden">
                 <div className="p-2">
+                    <AppKeyboardShortcuts />
                     <div className="text-xs text-muted-foreground">
                         <p>linux-wallpaperengine</p>
                         <p className="mt-0.5 opacity-60">v1.0.0</p>

--- a/src/renderer/components/playlist/playlist-editor-grid.tsx
+++ b/src/renderer/components/playlist/playlist-editor-grid.tsx
@@ -14,6 +14,9 @@ import { useWallpaperSearch } from "@/contexts/wallpaper-search-context"
 import { usePlaylistEditor } from "@/hooks/use-playlist-editor"
 import { useMemo, useCallback, useState, useRef } from "react"
 import { ErrorMessage } from "@/components/error-message"
+import { useHotkey } from "@tanstack/react-hotkeys"
+import { KeyboardShortcut } from "@/components/keyboard-shortcut"
+import { getAriaKeyShortcut, KEYBOARD_SHORTCUTS } from "@/lib/keyboard-shortcuts"
 
 interface PlaylistEditorGridProps {
     editPlaylist?: Playlist | null
@@ -40,6 +43,18 @@ export function PlaylistEditorGrid({ editPlaylist }: PlaylistEditorGridProps) {
     } = useWallpapers()
 
     const editor = usePlaylistEditor(editPlaylist)
+
+    useHotkey(KEYBOARD_SHORTCUTS.savePlaylist.hotkey, () => editor.form.handleSubmit(), {
+        enabled: !editor.isSaving,
+        ignoreInputs: false,
+        preventDefault: true,
+        stopPropagation: true,
+        conflictBehavior: "replace",
+        meta: {
+            name: KEYBOARD_SHORTCUTS.savePlaylist.label,
+            description: KEYBOARD_SHORTCUTS.savePlaylist.description,
+        },
+    })
 
     // Apply search-context filters and sorting
     const filteredWallpapers = useMemo(() =>
@@ -110,9 +125,14 @@ export function PlaylistEditorGrid({ editPlaylist }: PlaylistEditorGridProps) {
                         <Button variant="outline" onClick={editor.handleBack}>
                             Cancel
                         </Button>
-                        <Button onClick={() => editor.form.handleSubmit()} className="gap-2">
+                        <Button
+                            onClick={() => editor.form.handleSubmit()}
+                            aria-keyshortcuts={getAriaKeyShortcut("savePlaylist")}
+                            className="gap-2"
+                        >
                             <Save className="size-4" />
                             {editor.isSaving ? "Saving..." : "Save Playlist"}
+                            <KeyboardShortcut shortcut="savePlaylist" className="ml-1" />
                         </Button>
                     </div>
                 </div>

--- a/src/renderer/components/scroll-to-top-button.tsx
+++ b/src/renderer/components/scroll-to-top-button.tsx
@@ -56,6 +56,8 @@ export function ScrollToTopButton({ threshold = DEFAULT_THRESHOLD, className }: 
     <button
       ref={buttonRef}
       type="button"
+      tabIndex={isVisible ? 0 : -1}
+      aria-hidden={!isVisible}
       onClick={handleClick}
       className={cn(
         "fixed bottom-[calc(var(--status-bar-h,0rem)_+_0.5rem)] right-4 z-50",

--- a/src/renderer/components/search-input.tsx
+++ b/src/renderer/components/search-input.tsx
@@ -3,6 +3,8 @@ import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
 import { useRef } from "react"
+import { KeyboardShortcut } from "@/components/keyboard-shortcut"
+import { getAriaKeyShortcut } from "@/lib/keyboard-shortcuts"
 
 interface SearchInputProps {
   placeholder?: string
@@ -28,11 +30,14 @@ export function SearchInput({
           ref={inputRef}
           type="text"
           aria-label={placeholder}
+          aria-keyshortcuts={getAriaKeyShortcut("search")}
+          data-shortcut-search
           placeholder={placeholder}
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
           className="h-9 w-full rounded-xl border-0 bg-transparent pl-10 pr-10 text-sm font-medium tracking-wide text-foreground placeholder:text-muted-foreground/50 transition-all duration-200 focus:ring-0"
         />
+        {!searchQuery && <KeyboardShortcut shortcut="search" className="absolute right-2 top-1/2 -translate-y-1/2" />}
         {searchQuery && (
           <button
             type="button"

--- a/src/renderer/components/ui/kbd.tsx
+++ b/src/renderer/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from "~/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
+++ b/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
@@ -1,4 +1,5 @@
-import { useEffect, type ReactNode } from "react"
+import { type ReactNode } from "react"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import { X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -7,6 +8,7 @@ import { type Wallpaper } from "../wallpaper-card"
 import { WallpaperThumbnail } from "../wallpaper-thumbnail"
 import { WallpaperMetadata } from "./wallpaper-metadata"
 import { WallpaperTags } from "./wallpaper-tags"
+import { KEYBOARD_SHORTCUTS } from "@/lib/keyboard-shortcuts"
 
 interface WallpaperDetailsShellProps {
     wallpaper: Wallpaper
@@ -18,15 +20,18 @@ interface WallpaperDetailsShellProps {
 export function WallpaperDetailsShell({ wallpaper, onClose, actions, children }: WallpaperDetailsShellProps) {
     const glass = useGlass()
 
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key !== "Escape" || document.querySelector('[role="dialog"][data-state="open"]')) return
-            onClose()
-        }
-
-        document.addEventListener("keydown", handleKeyDown)
-        return () => document.removeEventListener("keydown", handleKeyDown)
-    }, [onClose])
+    useHotkey(KEYBOARD_SHORTCUTS.closeDetails.hotkey, () => {
+        if (!document.querySelector('[role="dialog"][data-state="open"]')) onClose()
+    }, {
+        ignoreInputs: false,
+        preventDefault: true,
+        stopPropagation: true,
+        conflictBehavior: "replace",
+        meta: {
+            name: KEYBOARD_SHORTCUTS.closeDetails.label,
+            description: KEYBOARD_SHORTCUTS.closeDetails.description,
+        },
+    })
 
     return (
         <div id="wallpaper-details" className={cn("sticky top-0 max-h-[calc(100vh_-_var(--status-bar-h,0rem)_-_2rem)] w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-card scrollbar-thin", glass)}>

--- a/src/renderer/lib/keyboard-shortcuts.ts
+++ b/src/renderer/lib/keyboard-shortcuts.ts
@@ -1,0 +1,97 @@
+import { normalizeRegisterableHotkey, type RegisterableHotkey } from "@tanstack/react-hotkeys"
+
+interface KeyboardShortcut {
+    hotkey: RegisterableHotkey
+    alternateHotkeys?: RegisterableHotkey[]
+    label: string
+    description: string
+    category: "Navigation" | "Actions" | "Grid"
+}
+
+export const KEYBOARD_SHORTCUTS = {
+    search: {
+        hotkey: "Mod+K",
+        alternateHotkeys: ["Mod+F"],
+        label: "Search",
+        description: "Focus search on the current page",
+        category: "Navigation",
+    },
+    installed: {
+        hotkey: "Mod+1",
+        label: "Installed wallpapers",
+        description: "Open installed wallpapers",
+        category: "Navigation",
+    },
+    workshop: {
+        hotkey: "Mod+2",
+        label: "Workshop",
+        description: "Open the Steam Workshop",
+        category: "Navigation",
+    },
+    playlists: {
+        hotkey: "Mod+3",
+        label: "Playlists",
+        description: "Open playlists",
+        category: "Navigation",
+    },
+    displays: {
+        hotkey: "Mod+4",
+        label: "Displays",
+        description: "Open display settings",
+        category: "Navigation",
+    },
+    settings: {
+        hotkey: "Mod+5",
+        label: "Settings",
+        description: "Open application settings",
+        category: "Navigation",
+    },
+    savePlaylist: {
+        hotkey: "Mod+S",
+        label: "Save playlist",
+        description: "Save the playlist being edited",
+        category: "Actions",
+    },
+    closeDetails: {
+        hotkey: "Escape",
+        label: "Close details",
+        description: "Close the active panel or dialog",
+        category: "Actions",
+    },
+    help: {
+        hotkey: { key: "/", shift: true },
+        label: "Keyboard shortcuts",
+        description: "Show this keyboard shortcut reference",
+        category: "Actions",
+    },
+    gridMove: {
+        hotkey: "ArrowRight",
+        label: "Move in grid",
+        description: "Use arrow keys to move between wallpaper cards",
+        category: "Grid",
+    },
+    gridRowEdge: {
+        hotkey: "Home",
+        label: "First or last in row",
+        description: "Use Home or End to move within a row",
+        category: "Grid",
+    },
+    gridEdge: {
+        hotkey: "Mod+Home",
+        label: "First or last wallpaper",
+        description: "Use the modifier with Home or End to cross the full grid",
+        category: "Grid",
+    },
+    activate: {
+        hotkey: "Enter",
+        label: "Activate",
+        description: "Use Enter or Space to activate the focused control",
+        category: "Grid",
+    },
+} as const satisfies Record<string, KeyboardShortcut>
+
+export type KeyboardShortcutId = keyof typeof KEYBOARD_SHORTCUTS
+
+export function getAriaKeyShortcut(id: KeyboardShortcutId) {
+    return normalizeRegisterableHotkey(KEYBOARD_SHORTCUTS[id].hotkey)
+}

--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -3,17 +3,20 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { AppShell } from '@/components/layout/app-shell'
 import { WallpaperSearchProvider } from '@/contexts/wallpaper-search-context'
 import { WorkshopSearchProvider } from '@/contexts/workshop-search-context'
+import { HotkeysProvider } from '@tanstack/react-hotkeys'
 
 export const Route = createRootRoute({
   component: () => (
-    <ThemeProvider defaultMode="dark" storageKey="wallpaper-engine-theme">
-      <WallpaperSearchProvider>
-        <WorkshopSearchProvider>
-          <AppShell>
-            <Outlet />
-          </AppShell>
-        </WorkshopSearchProvider>
-      </WallpaperSearchProvider>
-    </ThemeProvider>
+    <HotkeysProvider defaultOptions={{ hotkey: { conflictBehavior: "replace" } }}>
+      <ThemeProvider defaultMode="dark" storageKey="wallpaper-engine-theme">
+        <WallpaperSearchProvider>
+          <WorkshopSearchProvider>
+            <AppShell>
+              <Outlet />
+            </AppShell>
+          </WorkshopSearchProvider>
+        </WallpaperSearchProvider>
+      </ThemeProvider>
+    </HotkeysProvider>
   ),
 })

--- a/src/renderer/routes/playlists/index.tsx
+++ b/src/renderer/routes/playlists/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from "react"
+import { useState, useMemo, useRef } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Plus, Shuffle, Loader2, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -12,6 +12,8 @@ import { Input } from "@/components/ui/input"
 import { DebugLogDialog } from "@/components/wallpaper/debug-log-dialog"
 import { BackendNotInstalledDialog } from "@/components/wallpaper/backend-not-installed-dialog"
 import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE } from "../../../shared/constants/wallpaper"
+import { KeyboardShortcut } from "@/components/keyboard-shortcut"
+import { getAriaKeyShortcut } from "@/lib/keyboard-shortcuts"
 
 export const Route = createFileRoute("/playlists/")({
     component: PlaylistsPage,
@@ -37,17 +39,6 @@ function PlaylistsPage() {
             setIsSearchOpen(false)
         }
     }
-
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === "f" && (e.ctrlKey || e.metaKey)) {
-                e.preventDefault()
-                handleSearchOpen()
-            }
-        }
-        window.addEventListener("keydown", onKeyDown)
-        return () => window.removeEventListener("keydown", onKeyDown)
-    }, [])
 
     const { data: settings } = trpc.settings.get.useQuery()
     const { data: playlists = [], isLoading, refetch } = trpc.playlist.list.useQuery()
@@ -161,22 +152,29 @@ function PlaylistsPage() {
                             : "w-8"
                     )}>
                         <button
+                            type="button"
                             onClick={isSearchOpen ? undefined : handleSearchOpen}
                             className="absolute left-0 flex size-8 shrink-0 items-center justify-center text-muted-foreground/40 hover:text-muted-foreground transition-colors duration-200"
                             aria-label="Search playlists"
+                            aria-keyshortcuts={getAriaKeyShortcut("search")}
                         >
                             <Search className="size-4" />
                         </button>
                         <Input
                             ref={searchInputRef}
                             type="text"
+                            data-shortcut-search
+                            aria-label="Search playlists"
+                            aria-keyshortcuts={getAriaKeyShortcut("search")}
                             placeholder="Search playlists..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
+                            onFocus={() => setIsSearchOpen(true)}
                             onBlur={handleSearchClose}
                             onKeyDown={(e) => e.key === "Escape" && handleSearchClose()}
                             className="h-8 w-full border-0 bg-transparent pl-9 pr-4 text-sm font-medium tracking-wide text-foreground placeholder:text-muted-foreground/50 transition-all duration-200 focus:ring-0"
                         />
+                        {isSearchOpen && !searchQuery && <KeyboardShortcut shortcut="search" className="absolute right-2" />}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
Part 3 of the keyboard-only workflow stack. Depends on #105.

What changed
- pins @tanstack/react-hotkeys 0.10.0 and installs the shadcn Kbd component
- centralizes typed shortcut definitions and platform-aware display labels
- adds Mod+K / Mod+F search, Mod+1 through Mod+5 navigation, Mod+S playlist save, Escape close, and Shift+/ help
- replaces the playlists page manual key listener with TanStack Hotkeys
- adds a shortcut reference dialog, sidebar/search/save hints, and aria-keyshortcuts metadata
- keeps invisible error and scroll controls out of broken keyboard states

Verification
- TypeScript 5.9: tsc --noEmit passes
- git diff --check passes
- Vitest: 84 app tests pass; one unrelated existing settings reset assertion fails because dismissedUpdateVersion is now also persisted
- Vitest additionally discovers five unrelated pr-video skill test files outside the app suite

Stack
- Previous: #105
- This PR targets keyboard-navigation/grids