### PR TITLE
feat: add age ratings to installed wallpapers

### DIFF
--- a/src/main/services/store.ts
+++ b/src/main/services/store.ts
@@ -1,6 +1,6 @@
 import Store from 'electron-store'
 import { DEFAULT_SETTINGS, type AppSettings } from '../../shared/constants/app'
-import type { ApplyWallpaperOptions, WallpaperOverrides } from '../../shared/constants/wallpaper'
+import type { ApplyWallpaperOptions, WallpaperOverrides, AgeRating } from '../../shared/constants/wallpaper'
 
 // Store schemas
 export interface ActivePlaylistInfo {
@@ -20,12 +20,18 @@ export interface WallpaperOverridesSchema {
   overrides: Record<string, WallpaperOverrides>
 }
 
+export interface WorkshopMetadataSchema {
+  // Steam workshop item id -> age rating, resolved from Steam UGC tags
+  ageRatings: Record<string, AgeRating>
+}
+
 class StoreService {
   private static instance: StoreService | null = null
 
   readonly settings: Store<AppSettings>
   readonly activeWallpapers: Store<ActiveWallpapersSchema>
   readonly wallpaperOverrides: Store<WallpaperOverridesSchema>
+  readonly workshopMetadata: Store<WorkshopMetadataSchema>
 
   private constructor() {
     this.settings = new Store<AppSettings>({
@@ -48,6 +54,11 @@ class StoreService {
       defaults: {
         overrides: {},
       },
+    })
+
+    this.workshopMetadata = new Store<WorkshopMetadataSchema>({
+      name: 'workshop-metadata',
+      defaults: { ageRatings: {} },
     })
   }
 

--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -14,6 +14,8 @@ import { playlistService } from '../playlists/playlist'
 import { startPlaylistProcess } from '../playlists/playlist-runner'
 import { expandPath, parseWallpaperType, detectResolution, resolveThumbnail, parseWindowGeometry, resolveSteamLibraryPaths, resolveWallpaperEngineAssetsDir, resolveTimedCache, type TimedCache } from './wallpaper.utils'
 import { wallpaperStateManager } from './state-manager/state-manager'
+import { workshopService } from '@/services/workshop/workshop'
+import { parseWorkshopId } from '@/services/workshop/workshop.utils'
 import type { IWallpaperService } from './wallpaper.interface'
 import type { MutationResult, ActiveWallpaperEntry, ApplyTarget, OverrideMutation, ServiceAction, DebugInfo } from './wallpaper.types'
 
@@ -23,6 +25,7 @@ class WallpaperService implements IWallpaperService {
   private wallpaperCache: Wallpaper[] | null = null
   private wallpaperCacheEntry: TimedCache<Wallpaper[]> | null = null
   private overridesStore = storeService.wallpaperOverrides
+  private workshopMetadataStore = storeService.workshopMetadata
   private fsWatchers: fsSync.FSWatcher[] = []
   private reapplyTimer: ReturnType<typeof setTimeout> | null = null
   private state = wallpaperStateManager
@@ -246,6 +249,7 @@ class WallpaperService implements IWallpaperService {
               workshopId: itemId,
               title: project.title ?? 'Untitled',
               author: project.author ?? (project.workshopurl ? 'Workshop' : 'Unknown'),
+              ageRating: this.workshopMetadataStore.get('ageRatings')[itemId],
               type,
               thumbnail,
               previewUrl: project.preview ? path.join(wallpaperPath, project.preview) : undefined,
@@ -265,8 +269,40 @@ class WallpaperService implements IWallpaperService {
 
     wallpapers.sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()))
     this.startWatchers([...workshopDirs])
+    await this.enrichAgeRatings(wallpapers)
 
     return wallpapers
+  }
+
+  // Fetch + persist Steam age ratings for wallpapers missing a stored rating,
+  // then apply ratings to the given catalog list. Best-effort: fails silently
+  // when Steam is unavailable and retries on the next scan.
+  private async enrichAgeRatings(wallpapers: Wallpaper[]): Promise<number> {
+    try {
+      const cached = this.workshopMetadataStore.get('ageRatings')
+      const missingIds = Array.from(new Set(
+        wallpapers
+          .map(w => w.workshopId ?? w.id)
+          .filter(id => parseWorkshopId(id) != null && cached[id] === undefined),
+      ))
+
+      if (missingIds.length > 0) {
+        const fetched = await workshopService.getAgeRatings(missingIds)
+        this.workshopMetadataStore.set('ageRatings', { ...cached, ...fetched })
+        Object.assign(cached, fetched)
+      }
+
+      for (const w of wallpapers) {
+        if (w.workshopId && cached[w.workshopId] !== undefined) {
+          w.ageRating = cached[w.workshopId]
+        }
+      }
+
+      return missingIds.length
+    } catch (error) {
+      console.warn('[enrichAgeRatings] Steam unavailable — age ratings not refreshed', error)
+      return 0
+    }
   }
 
   // ── Private: active wallpaper enrichment ───────────────────────────────

--- a/src/main/services/wallpaper/wallpaper.ts
+++ b/src/main/services/wallpaper/wallpaper.ts
@@ -7,7 +7,7 @@ import { settingsService, type AppSettings } from '../settings'
 import { storeService } from '../store'
 import { hostSpawn, hostExecAsync, hostCommandExists, isFlatpak } from '../../utils/host'
 import { WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
-import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE, pickScanManagedFields, type ApplyWallpaperOptions, type Wallpaper, type WallpaperOverrides } from '../../../shared/constants/wallpaper'
+import { BACKEND_NOT_INSTALLED_ERROR_MESSAGE, pickScanManagedFields, type AgeRating, type ApplyWallpaperOptions, type Wallpaper, type WallpaperOverrides } from '../../../shared/constants/wallpaper'
 import { invalidationService } from '../invalidation'
 import { compatibilityService } from '../compatibility'
 import { playlistService } from '../playlists/playlist'
@@ -249,7 +249,6 @@ class WallpaperService implements IWallpaperService {
               workshopId: itemId,
               title: project.title ?? 'Untitled',
               author: project.author ?? (project.workshopurl ? 'Workshop' : 'Unknown'),
-              ageRating: this.workshopMetadataStore.get('ageRatings')[itemId],
               type,
               thumbnail,
               previewUrl: project.preview ? path.join(wallpaperPath, project.preview) : undefined,
@@ -277,9 +276,11 @@ class WallpaperService implements IWallpaperService {
   // Fetch + persist Steam age ratings for wallpapers missing a stored rating,
   // then apply ratings to the given catalog list. Best-effort: fails silently
   // when Steam is unavailable and retries on the next scan.
-  private async enrichAgeRatings(wallpapers: Wallpaper[]): Promise<number> {
+  private async enrichAgeRatings(wallpapers: Wallpaper[]): Promise<void> {
+    let cached: Record<string, AgeRating> = {}
+
     try {
-      const cached = this.workshopMetadataStore.get('ageRatings')
+      cached = this.workshopMetadataStore.get('ageRatings')
       const missingIds = Array.from(new Set(
         wallpapers
           .map(w => w.workshopId ?? w.id)
@@ -291,17 +292,15 @@ class WallpaperService implements IWallpaperService {
         this.workshopMetadataStore.set('ageRatings', { ...cached, ...fetched })
         Object.assign(cached, fetched)
       }
-
-      for (const w of wallpapers) {
-        if (w.workshopId && cached[w.workshopId] !== undefined) {
-          w.ageRating = cached[w.workshopId]
-        }
-      }
-
-      return missingIds.length
     } catch (error) {
       console.warn('[enrichAgeRatings] Steam unavailable — age ratings not refreshed', error)
-      return 0
+    }
+
+    for (const w of wallpapers) {
+      const id = w.workshopId ?? w.id
+      if (cached[id] !== undefined) {
+        w.ageRating = cached[id]
+      }
     }
   }
 

--- a/src/main/services/workshop/workshop.interface.ts
+++ b/src/main/services/workshop/workshop.interface.ts
@@ -1,5 +1,6 @@
 import type { WorkshopDiscoverOptions, WorkshopDiscoverResult, WorkshopQueryOptions, WorkshopQueryResult, WorkshopStatus } from './workshop.types'
 import type { WorkshopConnectionEvent } from './workshop'
+import type { AgeRating } from '@/../shared/constants/wallpaper'
 
 export interface IWorkshopService {
   /**
@@ -35,4 +36,11 @@ export interface IWorkshopService {
    * active download progress when available.
    */
   itemStatus(workshopId: string): Promise<WorkshopStatus | null>
+
+  /**
+   * Resolves age ratings for the given workshop item ids from Steam UGC tags.
+   * Only numeric workshop ids are queried; unknown items are skipped.
+   * Throws when Steam is unavailable (callers should catch).
+   */
+  getAgeRatings(workshopIds: string[]): Promise<Record<string, AgeRating>>
 }

--- a/src/main/services/workshop/workshop.ts
+++ b/src/main/services/workshop/workshop.ts
@@ -2,11 +2,12 @@ import { execFile } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { promisify } from 'node:util'
 import { WALLPAPER_ENGINE_APP_ID } from '../../../shared/constants/app'
+import type { AgeRating } from '@/../shared/constants/wallpaper'
 import { settingsService } from '../settings'
 import type { IWorkshopService } from './workshop.interface'
 import type { WorkshopDiscoverOptions, WorkshopDiscoverResult, WorkshopItem as AppWorkshopItem, WorkshopQueryOptions, WorkshopQueryResult, WorkshopStatus } from './workshop.types'
 import { createWorkshopConnectionError } from './workshop.errors'
-import { buildFilterCombinations, mapWorkshopItems, mergeWorkshopItemsBySource, parseWorkshopId, settleWorkshopPageResults, shuffleDiscoverSectionConfigs, toSafeNumber } from './workshop.utils'
+import { buildFilterCombinations, mapWorkshopAgeRatings, mapWorkshopItems, mergeWorkshopItemsBySource, parseWorkshopId, settleWorkshopPageResults, shuffleDiscoverSectionConfigs, toSafeNumber } from '@/services/workshop/workshop.utils'
 import { decodeWorkshopCursor } from '../../../shared/utils/workshop-cursor'
 import { DISCOVER_PAGE, DISCOVER_SECTION_LIMIT, UGC_QUERY_TYPE_RANKED_BY_TREND, UGC_QUERY_TYPE_RANKED_BY_TEXT_SEARCH, UGC_TYPE_ITEMS_READY_TO_USE, CURATED_DISCOVER_SECTION_CONFIGS, PINNED_DISCOVER_SECTION_CONFIGS, WORKSHOP_SORT_TO_QUERY_TYPE, WORKSHOP_TREND_DAYS, WORKSHOP_MAX_RESULTS } from '../../../shared/constants/workshop'
 
@@ -17,6 +18,9 @@ export type WorkshopConnectionEvent = 'connected' | 'disconnected'
 
 const execFileAsync = promisify(execFile)
 const AUTO_CONNECT_INTERVAL_MS = 3000
+
+// Steam UGC details requests currently accept up to 1,000 ids per call (https://partner.steamgames.com/doc/api/ISteamUGC#CreateQueryUGCDetailsRequest)
+const WORKSHOP_DETAILS_BATCH_SIZE = 1000
 
 class WorkshopService implements IWorkshopService {
     private static instance: WorkshopService | null = null
@@ -280,6 +284,24 @@ class WorkshopService implements IWorkshopService {
                 }
                 : null,
         }
+    }
+
+    async getAgeRatings(workshopIds: string[]): Promise<Record<string, AgeRating>> {
+        const client = await this.getClient()
+        const uniqueIds = Array.from(new Set(
+            workshopIds
+                .map(id => parseWorkshopId(id))
+                .filter((id): id is bigint => id != null),
+        ))
+        const ratings: Record<string, AgeRating> = {}
+
+        for (let i = 0; i < uniqueIds.length; i += WORKSHOP_DETAILS_BATCH_SIZE) {
+            const chunk = uniqueIds.slice(i, i + WORKSHOP_DETAILS_BATCH_SIZE)
+            const { items } = await client.workshop.getItems(chunk)
+            Object.assign(ratings, mapWorkshopAgeRatings(items))
+        }
+
+        return ratings
     }
 
     private async resolveWorkshopContext(workshopId: string): Promise<{ client: SteamClient; itemId: bigint } | null> {

--- a/src/main/services/workshop/workshop.utils.test.ts
+++ b/src/main/services/workshop/workshop.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { mapWorkshopAgeRatings, parseWorkshopAgeRating } from './workshop.utils'
+
+describe('parseWorkshopAgeRating', () => {
+  it("returns 'g' for the Everyone tag", () => {
+    expect(parseWorkshopAgeRating(['Scene', 'Everyone'])).toBe('g')
+  })
+
+  it("returns 'pg13' for the Questionable tag", () => {
+    expect(parseWorkshopAgeRating(['Video', 'Questionable'])).toBe('pg13')
+  })
+
+  it("returns 'r' for the Mature tag", () => {
+    expect(parseWorkshopAgeRating(['Web', 'Mature'])).toBe('r')
+  })
+
+  it('matches tags case-insensitively', () => {
+    expect(parseWorkshopAgeRating(['scene', 'mAtUrE'])).toBe('r')
+  })
+
+  it('returns undefined for empty or unmatched tags', () => {
+    expect(parseWorkshopAgeRating([])).toBeUndefined()
+    expect(parseWorkshopAgeRating(['Scene', '4K Ultra HD'])).toBeUndefined()
+  })
+})
+
+describe('mapWorkshopAgeRatings', () => {
+  it('maps a single item id to its resolved age rating', () => {
+    const ratings = mapWorkshopAgeRatings([{ publishedFileId: BigInt('123'), tags: ['Scene', 'Everyone'] }])
+    expect(ratings).toEqual({ '123': 'g' })
+  })
+
+  it('skips null and undefined items', () => {
+    const ratings = mapWorkshopAgeRatings([
+      { publishedFileId: BigInt('123'), tags: ['Scene', 'Everyone'] },
+      null,
+      undefined,
+    ])
+    expect(ratings).toEqual({ '123': 'g' })
+  })
+
+  it('skips items with no matching rating tag', () => {
+    const ratings = mapWorkshopAgeRatings([{ publishedFileId: BigInt('456'), tags: ['Scene', '4K Ultra HD'] }])
+    expect(ratings).toEqual({})
+  })
+
+  it('maps multiple items', () => {
+    const ratings = mapWorkshopAgeRatings([
+      { publishedFileId: BigInt('123'), tags: ['Scene', 'Everyone'] },
+      { publishedFileId: BigInt('789'), tags: ['Video', 'Questionable'] },
+    ])
+    expect(ratings).toEqual({ '123': 'g', '789': 'pg13' })
+  })
+})

--- a/src/main/services/workshop/workshop.utils.ts
+++ b/src/main/services/workshop/workshop.utils.ts
@@ -45,6 +45,19 @@ export function parseWorkshopAgeRating(tags: string[]): AgeRating | undefined {
   return undefined
 }
 
+// Best-effort map of workshop item id -> age rating from raw steamworks item payloads
+export function mapWorkshopAgeRatings(
+  items: Array<{ publishedFileId: bigint; tags: string[] } | null | undefined>,
+): Record<string, AgeRating> {
+  const ratings: Record<string, AgeRating> = {}
+  for (const item of items) {
+    if (!item) continue
+    const rating = parseWorkshopAgeRating(item.tags)
+    if (rating) ratings[item.publishedFileId.toString()] = rating
+  }
+  return ratings
+}
+
 export function parseWorkshopType(tags: string[]): WallpaperType {
   const normalizedTags = new Set(tags.map(tag => tag.trim().toLowerCase()))
 


### PR DESCRIPTION
This change covers the following:
* Adds a Workshop Metadata Store for downloaded wallpaper's age ratings
* Updates all downloaded wallpapers lacking a store
* Fixes the age rating filter to actually filter downloaded items based on their age ratings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->