### PR TITLE
Unify wallpaper grid layouts and add configurable density

### DIFF
--- a/src/main/trpc/routes/settings.test.ts
+++ b/src/main/trpc/routes/settings.test.ts
@@ -109,13 +109,15 @@ describe('settingsRouter', () => {
         expect(mockWallpaperService.apply).toHaveBeenCalledWith({ kind: 'reapply' })
       })
 
-      const NON_BACKEND_KEYS = ['theme', 'launchOnLogin', 'enableSystemTray', 'minimizeOnClose'] as const
+      const NON_BACKEND_KEYS = ['theme', 'wallpaperGridDensity', 'launchOnLogin', 'enableSystemTray', 'minimizeOnClose'] as const
 
       it.each(NON_BACKEND_KEYS)('should NOT reapply wallpapers when %s changes', async (key) => {
         mockSettingsService.saveSettings.mockResolvedValue(makeSettings())
 
         const input: Record<string, unknown> = {}
-        if (typeof DEFAULT_SETTINGS[key] === 'boolean') {
+        if (key === 'wallpaperGridDensity') {
+          input[key] = 'compact'
+        } else if (typeof DEFAULT_SETTINGS[key] === 'boolean') {
           input[key] = !DEFAULT_SETTINGS[key]
         } else {
           input[key] = 'dark'

--- a/src/main/trpc/routes/settings.ts
+++ b/src/main/trpc/routes/settings.ts
@@ -8,6 +8,7 @@ import { AGE_RATING_OPTIONS, FILTER_TYPE_OPTIONS, type AgeRating, type Wallpaper
 import { COMPATIBILITY_OPTIONS, type CompatibilityStatus } from '../../../shared/constants/compatibility'
 import { SORT_OPTIONS, type SortBy, SORT_ORDER_OPTIONS, type SortOrder } from '../../../shared/constants/sort'
 import { WORKSHOP_SORT_OPTIONS, type WorkshopSortBy } from '../../../shared/constants/workshop'
+import { WALLPAPER_GRID_DENSITY_OPTIONS, type WallpaperGridDensity } from '../../../shared/constants/grid'
 import { isFlatpak, setFlatpakBypass } from '../../utils/host'
 import { setAutostart } from '../../utils/autostart'
 import { systemThemeService } from '../../services/system-theme/system-theme'
@@ -57,6 +58,7 @@ const settingsSchema = z.object({
   showCompatibilityDot: z.boolean().optional(),
   showStatusBar: z.boolean().optional(),
   dynamicBackground: z.boolean().optional(),
+  wallpaperGridDensity: z.enum(WALLPAPER_GRID_DENSITY_OPTIONS.map(o => o.value) as [WallpaperGridDensity, ...WallpaperGridDensity[]]).optional(),
   dismissedScanReminder: z.boolean().optional(),
   dismissedUpdateVersion: z.string().nullable().optional(),
 

--- a/src/renderer/components/playlist/playlist-editor-grid.tsx
+++ b/src/renderer/components/playlist/playlist-editor-grid.tsx
@@ -171,6 +171,7 @@ export function PlaylistEditorGrid({ editPlaylist }: PlaylistEditorGridProps) {
                 isLoading={isLoading}
                 compatibilityMap={compatibilityMap}
                 showCompatibilityDot={appSettings?.showCompatibilityDot ?? true}
+                density={appSettings?.wallpaperGridDensity}
                 isSelected={(w) => editor.selectedSet.has(w.path)}
                 onCardClick={editor.handleToggleWallpaper}
                 emptyMessage="No wallpapers found"

--- a/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
+++ b/src/renderer/components/wallpaper/details-card/wallpaper-details-shell.tsx
@@ -19,7 +19,7 @@ export function WallpaperDetailsShell({ wallpaper, onClose, actions, children }:
     const glass = useGlass()
 
     return (
-        <div id="wallpaper-details" className={cn("sticky top-0 max-h-[calc(100vh_-_var(--status-bar-h,0rem)_-_2rem)] w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-card scrollbar-thin", glass)}>
+        <div id="wallpaper-details" className={cn("sticky top-0 max-h-[calc(100vh_-_var(--status-bar-h,0rem)_-_2rem)] w-full shrink-0 overflow-y-auto rounded-xl border border-border bg-card scrollbar-thin", glass)}>
             <div className="sticky top-2 z-10 flex justify-end pr-2 h-0">
                 <Button
                     variant="ghost"

--- a/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
@@ -8,11 +8,11 @@ import { WallpaperCard } from "./wallpaper-card"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
 import type { WallpaperGridDensity } from "../../../shared/constants/grid"
+import { WALLPAPER_GRID_GAP, WALLPAPER_GRID_SKELETON_COUNT } from "../../../shared/constants/grid"
 import { findScrollParent, columnsForWidth } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
 import { WALLPAPER_GRID_TRANSITION } from "./wallpaper-grid-shell"
 
-const GAP = 16 // matches gap-4 (1rem)
 const OVERSCAN = 3 // rows rendered beyond the viewport to smooth scrolling
 
 export interface VirtualizedWallpaperGridHandle {
@@ -61,7 +61,6 @@ export function VirtualizedWallpaperGrid({
     const glass = useGlass()
     const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
     const [width, setWidth] = useState(0)
-    const [viewportHeight, setViewportHeight] = useState(0)
     const [scrollMargin, setScrollMargin] = useState(0)
 
     // Resolve the scroll container once mounted.
@@ -78,7 +77,6 @@ export function VirtualizedWallpaperGrid({
         const measure = () => {
             setWidth(node.clientWidth)
             if (scrollEl) {
-                setViewportHeight(scrollEl.clientHeight)
                 const parentRect = node.getBoundingClientRect()
                 const scrollRect = scrollEl.getBoundingClientRect()
                 setScrollMargin(scrollEl.scrollTop + parentRect.top - scrollRect.top)
@@ -94,13 +92,9 @@ export function VirtualizedWallpaperGrid({
     // Breakpoints are applied to the container width (not the viewport), so the
     // column count adapts when side panels narrow the grid.
     const columns = columnsOverride ?? columnsForWidth(width, density)
-    const cardWidth = columns > 0 ? (width - GAP * (columns - 1)) / columns : 0
-    const rowHeight = cardWidth + GAP // cards are square (aspect-square)
+    const cardWidth = columns > 0 ? (width - WALLPAPER_GRID_GAP * (columns - 1)) / columns : 0
+    const rowHeight = cardWidth + WALLPAPER_GRID_GAP // cards are square (aspect-square)
     const rowCount = Math.ceil(wallpapers.length / columns)
-
-    // Fill the visible viewport with skeletons rather than a fixed count.
-    const skeletonRows = rowHeight > 0 ? Math.ceil((viewportHeight || rowHeight * 3) / rowHeight) : 3
-    const skeletonCount = columns * skeletonRows
 
     const virtualizer = useVirtualizer({
         count: rowCount,
@@ -131,7 +125,7 @@ export function VirtualizedWallpaperGrid({
             className="grid gap-4"
             style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
         >
-            {Array.from({ length: skeletonCount }).map((_, i) => (
+            {Array.from({ length: WALLPAPER_GRID_SKELETON_COUNT }).map((_, i) => (
                 <Skeleton key={i} className="aspect-square rounded-xl" />
             ))}
         </div>
@@ -156,7 +150,7 @@ export function VirtualizedWallpaperGrid({
                                 width: "100%",
                                 transform: `translateY(${virtualRow.start - scrollMargin}px)`,
                                 gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                                paddingBottom: GAP,
+                                paddingBottom: WALLPAPER_GRID_GAP,
                             }}
                         >
                             {rowItems.map((wallpaper) => (

--- a/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx
@@ -1,13 +1,16 @@
-import { useImperativeHandle, useLayoutEffect, useRef, useState, type ReactNode, type Ref } from "react"
+import { useId, useImperativeHandle, useLayoutEffect, useRef, useState, type ReactNode, type Ref } from "react"
 import { FolderOpen, type LucideIcon } from "lucide-react"
 import { useVirtualizer } from "@tanstack/react-virtual"
+import { LayoutGroup, motion } from "framer-motion"
 import { Skeleton } from "@/components/ui/skeleton"
 import { EmptyState } from "@/components/empty-state"
 import { WallpaperCard } from "./wallpaper-card"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
-import { findScrollParent, DEFAULT_GRID_COLS, columnsForWidth } from "@/lib/utils"
+import type { WallpaperGridDensity } from "../../../shared/constants/grid"
+import { findScrollParent, columnsForWidth } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
+import { WALLPAPER_GRID_TRANSITION } from "./wallpaper-grid-shell"
 
 const GAP = 16 // matches gap-4 (1rem)
 const OVERSCAN = 3 // rows rendered beyond the viewport to smooth scrolling
@@ -29,6 +32,8 @@ interface VirtualizedWallpaperGridProps {
     emptyMessage?: string
     emptySubMessage?: string
     renderCardOverlay?: (wallpaper: Wallpaper) => ReactNode
+    columns?: number
+    density?: WallpaperGridDensity
     ref?: Ref<VirtualizedWallpaperGridHandle>
 }
 
@@ -46,9 +51,12 @@ export function VirtualizedWallpaperGrid({
     emptyMessage = "No wallpapers found",
     emptySubMessage,
     renderCardOverlay,
+    columns: columnsOverride,
+    density,
     ref,
 }: VirtualizedWallpaperGridProps) {
     const parentRef = useRef<HTMLDivElement>(null)
+    const layoutGroupId = useId()
     // Resolved once for the whole grid — cards must not subscribe individually.
     const glass = useGlass()
     const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
@@ -85,7 +93,7 @@ export function VirtualizedWallpaperGrid({
 
     // Breakpoints are applied to the container width (not the viewport), so the
     // column count adapts when side panels narrow the grid.
-    const columns = columnsForWidth(width)
+    const columns = columnsOverride ?? columnsForWidth(width, density)
     const cardWidth = columns > 0 ? (width - GAP * (columns - 1)) / columns : 0
     const rowHeight = cardWidth + GAP // cards are square (aspect-square)
     const rowCount = Math.ceil(wallpapers.length / columns)
@@ -119,7 +127,10 @@ export function VirtualizedWallpaperGrid({
     }), [virtualizer, wallpapers, columns])
 
     const skeleton = (
-        <div className={`grid gap-4 ${DEFAULT_GRID_COLS}`}>
+        <div
+            className="grid gap-4"
+            style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
             {Array.from({ length: skeletonCount }).map((_, i) => (
                 <Skeleton key={i} className="aspect-square rounded-xl" />
             ))}
@@ -127,43 +138,52 @@ export function VirtualizedWallpaperGrid({
     )
 
     const rows = (
-        <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
-            {virtualizer.getVirtualItems().map((virtualRow) => {
-                const start = virtualRow.index * columns
-                const rowItems = wallpapers.slice(start, start + columns)
-                return (
-                    <div
-                        key={virtualRow.key}
-                        data-index={virtualRow.index}
-                        ref={virtualizer.measureElement}
-                        className="grid gap-4"
-                        style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            transform: `translateY(${virtualRow.start - scrollMargin}px)`,
-                            gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                            paddingBottom: GAP,
-                        }}
-                    >
-                        {rowItems.map((wallpaper) => (
-                            <div key={wallpaper.id} className="relative" data-wallpaper-path={wallpaper.path}>
-                                <WallpaperCard
-                                    wallpaper={wallpaper}
-                                    selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
-                                    onClick={onCardClick}
-                                    compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
-                                    showCompatibilityDot={showCompatibilityDot}
-                                    glassClassName={glass}
-                                />
-                                {renderCardOverlay?.(wallpaper)}
-                            </div>
-                        ))}
-                    </div>
-                )
-            })}
-        </div>
+        <LayoutGroup id={layoutGroupId}>
+            <div style={{ height: virtualizer.getTotalSize(), position: "relative", width: "100%" }}>
+                {virtualizer.getVirtualItems().map((virtualRow) => {
+                    const start = virtualRow.index * columns
+                    const rowItems = wallpapers.slice(start, start + columns)
+                    return (
+                        <div
+                            key={virtualRow.key}
+                            data-index={virtualRow.index}
+                            ref={virtualizer.measureElement}
+                            className="grid gap-4"
+                            style={{
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                width: "100%",
+                                transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                                paddingBottom: GAP,
+                            }}
+                        >
+                            {rowItems.map((wallpaper) => (
+                                <motion.div
+                                    key={wallpaper.id}
+                                    layout
+                                    layoutId={wallpaper.id}
+                                    transition={WALLPAPER_GRID_TRANSITION}
+                                    className="relative"
+                                    data-wallpaper-path={wallpaper.path}
+                                >
+                                    <WallpaperCard
+                                        wallpaper={wallpaper}
+                                        selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
+                                        onClick={onCardClick}
+                                        compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                                        showCompatibilityDot={showCompatibilityDot}
+                                        glassClassName={glass}
+                                    />
+                                    {renderCardOverlay?.(wallpaper)}
+                                </motion.div>
+                            ))}
+                        </div>
+                    )
+                })}
+            </div>
+        </LayoutGroup>
     )
 
     // The parentRef div is now always mounted so the layout effects above can

--- a/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
@@ -1,4 +1,4 @@
-import { useId, type ReactNode } from "react"
+import { memo, useId, type ReactNode } from "react"
 import { LayoutGroup, motion } from "framer-motion"
 import { FolderOpen, type LucideIcon } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -24,6 +24,48 @@ interface WallpaperGridLayoutProps {
     renderCardOverlay?: (wallpaper: Wallpaper) => ReactNode
     columns: number
 }
+
+interface WallpaperGridCardItemProps {
+    wallpaper: Wallpaper
+    selected: boolean
+    onClick: (wallpaper: Wallpaper) => void
+    compatibilityStatus?: CompatibilityStatus
+    showCompatibilityDot: boolean
+    glassClassName: string
+    overlay?: ReactNode
+}
+
+// Memoized so a parent re-render (e.g. selection change) only re-renders the
+// cards whose props actually changed, not the whole grid.
+const WallpaperGridCardItem = memo(function WallpaperGridCardItem({
+    wallpaper,
+    selected,
+    onClick,
+    compatibilityStatus,
+    showCompatibilityDot,
+    glassClassName,
+    overlay,
+}: WallpaperGridCardItemProps) {
+    return (
+        <motion.div
+            layout
+            layoutId={wallpaper.id}
+            transition={WALLPAPER_GRID_TRANSITION}
+            className="relative"
+            data-wallpaper-path={wallpaper.path}
+        >
+            <WallpaperCard
+                wallpaper={wallpaper}
+                selected={selected}
+                onClick={onClick}
+                compatibilityStatus={compatibilityStatus}
+                showCompatibilityDot={showCompatibilityDot}
+                glassClassName={glassClassName}
+            />
+            {overlay}
+        </motion.div>
+    )
+})
 
 export function WallpaperGridLayout({
     wallpapers,
@@ -62,24 +104,16 @@ export function WallpaperGridLayout({
         <LayoutGroup id={layoutGroupId}>
             <div className="grid gap-4" style={gridStyle}>
                 {wallpapers.map((wallpaper) => (
-                    <motion.div
+                    <WallpaperGridCardItem
                         key={wallpaper.id}
-                        layout
-                        layoutId={wallpaper.id}
-                        transition={WALLPAPER_GRID_TRANSITION}
-                        className="relative"
-                        data-wallpaper-path={wallpaper.path}
-                    >
-                        <WallpaperCard
-                            wallpaper={wallpaper}
-                            selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
-                            onClick={onCardClick}
-                            compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
-                            showCompatibilityDot={showCompatibilityDot}
-                            glassClassName={glass}
-                        />
-                        {renderCardOverlay?.(wallpaper)}
-                    </motion.div>
+                        wallpaper={wallpaper}
+                        selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
+                        onClick={onCardClick}
+                        compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                        showCompatibilityDot={showCompatibilityDot}
+                        glassClassName={glass}
+                        overlay={renderCardOverlay?.(wallpaper)}
+                    />
                 ))}
             </div>
         </LayoutGroup>

--- a/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
@@ -1,12 +1,13 @@
-import { type ReactNode } from "react"
+import { useId, type ReactNode } from "react"
+import { LayoutGroup, motion } from "framer-motion"
 import { FolderOpen, type LucideIcon } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { EmptyState } from "@/components/empty-state"
 import { WallpaperCard } from "./wallpaper-card"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
-import { DEFAULT_GRID_COLS } from "@/lib/utils"
 import { useGlass } from "@/hooks/use-glass"
+import { WALLPAPER_GRID_TRANSITION } from "./wallpaper-grid-shell"
 
 const SKELETON_COUNT = 12
 
@@ -22,7 +23,7 @@ interface WallpaperGridLayoutProps {
     emptyMessage?: string
     emptySubMessage?: string
     renderCardOverlay?: (wallpaper: Wallpaper) => ReactNode
-    gridClassName?: string
+    columns: number
 }
 
 export function WallpaperGridLayout({
@@ -37,17 +38,18 @@ export function WallpaperGridLayout({
     emptyMessage = "No wallpapers found",
     emptySubMessage,
     renderCardOverlay,
-    gridClassName,
+    columns,
 }: WallpaperGridLayoutProps) {
-    const gridCols = DEFAULT_GRID_COLS
     // Resolved once for the whole grid — cards must not subscribe individually.
     const glass = useGlass()
+    const layoutGroupId = useId()
+    const gridStyle = { gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }
 
     if (isLoading) {
         return (
-            <div className={`grid gap-4 ${gridCols}`}>
+            <div className="grid gap-4" style={gridStyle}>
                 {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                    <Skeleton key={i} className="aspect-[4/3] rounded-xl" />
+                    <Skeleton key={i} className="aspect-square rounded-xl" />
                 ))}
             </div>
         )
@@ -58,20 +60,29 @@ export function WallpaperGridLayout({
     }
 
     return (
-        <div className={`grid gap-4 ${gridCols}`}>
-            {wallpapers.map((wallpaper) => (
-                <div key={wallpaper.id} className="relative" data-wallpaper-path={wallpaper.path}>
-                    <WallpaperCard
-                        wallpaper={wallpaper}
-                        selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
-                        onClick={onCardClick}
-                        compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
-                        showCompatibilityDot={showCompatibilityDot}
-                        glassClassName={glass}
-                    />
-                    {renderCardOverlay?.(wallpaper)}
-                </div>
-            ))}
-        </div>
+        <LayoutGroup id={layoutGroupId}>
+            <div className="grid gap-4" style={gridStyle}>
+                {wallpapers.map((wallpaper) => (
+                    <motion.div
+                        key={wallpaper.id}
+                        layout
+                        layoutId={wallpaper.id}
+                        transition={WALLPAPER_GRID_TRANSITION}
+                        className="relative"
+                        data-wallpaper-path={wallpaper.path}
+                    >
+                        <WallpaperCard
+                            wallpaper={wallpaper}
+                            selected={isSelected?.(wallpaper) ?? selectedId === wallpaper.id}
+                            onClick={onCardClick}
+                            compatibilityStatus={compatibilityMap?.[wallpaper.path ?? ""]}
+                            showCompatibilityDot={showCompatibilityDot}
+                            glassClassName={glass}
+                        />
+                        {renderCardOverlay?.(wallpaper)}
+                    </motion.div>
+                ))}
+            </div>
+        </LayoutGroup>
     )
 }

--- a/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-layout.tsx
@@ -6,10 +6,9 @@ import { EmptyState } from "@/components/empty-state"
 import { WallpaperCard } from "./wallpaper-card"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
+import { WALLPAPER_GRID_SKELETON_COUNT } from "../../../shared/constants/grid"
 import { useGlass } from "@/hooks/use-glass"
 import { WALLPAPER_GRID_TRANSITION } from "./wallpaper-grid-shell"
-
-const SKELETON_COUNT = 12
 
 interface WallpaperGridLayoutProps {
     wallpapers: Wallpaper[]
@@ -48,7 +47,7 @@ export function WallpaperGridLayout({
     if (isLoading) {
         return (
             <div className="grid gap-4" style={gridStyle}>
-                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                {Array.from({ length: WALLPAPER_GRID_SKELETON_COUNT }).map((_, i) => (
                     <Skeleton key={i} className="aspect-square rounded-xl" />
                 ))}
             </div>

--- a/src/renderer/components/wallpaper/wallpaper-grid-shell.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-shell.tsx
@@ -1,0 +1,95 @@
+import { useLayoutEffect, useRef, useState, type Key, type ReactNode } from "react"
+import { AnimatePresence, LayoutGroup, motion } from "framer-motion"
+import { columnsForWidth } from "@/lib/utils"
+import { trpc } from "@/lib/trpc"
+import { DEFAULT_WALLPAPER_GRID_DENSITY } from "../../../shared/constants/grid"
+
+const GRID_GAP = 16 // matches gap-4
+const WALLPAPER_DETAILS_MIN_WIDTH = 320 // matches the original Installed w-80 panel
+export const WALLPAPER_GRID_TRANSITION = { duration: 0.3, ease: "easeOut" } as const
+
+interface WallpaperGridShellProps {
+    children: (columns: number) => ReactNode
+    details: ReactNode | null
+    detailsKey?: Key
+}
+
+/**
+ * Shared responsive shell for wallpaper grids and their details panel.
+ *
+ * The panel keeps the shared details width. The grid calculates its columns
+ * from the space left beside it, so Installed and Workshop use the same card
+ * minimums and animation timing.
+ */
+export function WallpaperGridShell({ children, details, detailsKey }: WallpaperGridShellProps) {
+    const shellRef = useRef<HTMLDivElement>(null)
+    const [width, setWidth] = useState(0)
+    const [reserveDetailsColumn, setReserveDetailsColumn] = useState(details !== null)
+    const hasDetails = details !== null
+    const { data: settings } = trpc.settings.get.useQuery()
+
+    useLayoutEffect(() => {
+        const node = shellRef.current
+        if (!node) return
+
+        const measure = () => setWidth(node.clientWidth)
+        measure()
+
+        const observer = new ResizeObserver(measure)
+        observer.observe(node)
+        return () => observer.disconnect()
+    }, [])
+
+    // Reserve the column before paint when opening. On close it remains reserved
+    // until the panel finishes shrinking, so the last grid reflow is not abrupt.
+    useLayoutEffect(() => {
+        if (hasDetails) setReserveDetailsColumn(true)
+    }, [hasDetails])
+
+    const density = settings?.wallpaperGridDensity ?? DEFAULT_WALLPAPER_GRID_DENSITY
+    const gridWidth = reserveDetailsColumn
+        ? Math.max(0, width - WALLPAPER_DETAILS_MIN_WIDTH - GRID_GAP)
+        : width
+    const gridColumns = columnsForWidth(gridWidth, density)
+
+    return (
+        <LayoutGroup>
+            <div ref={shellRef} className="flex flex-1 items-start">
+                <div className="min-w-0 flex-1 h-fit">
+                    {children(gridColumns)}
+                </div>
+
+                <aside
+                    className="sticky top-0 min-w-0 shrink-0 overflow-hidden"
+                    style={{
+                        width: reserveDetailsColumn ? WALLPAPER_DETAILS_MIN_WIDTH : 0,
+                        minWidth: reserveDetailsColumn ? WALLPAPER_DETAILS_MIN_WIDTH : 0,
+                        marginLeft: reserveDetailsColumn ? GRID_GAP : 0,
+                        pointerEvents: hasDetails ? "auto" : "none",
+                    }}
+                >
+                    <AnimatePresence
+                        initial={false}
+                        mode="wait"
+                        onExitComplete={() => {
+                            if (!hasDetails) setReserveDetailsColumn(false)
+                        }}
+                    >
+                        {details && (
+                            <motion.div
+                                key={detailsKey ?? "wallpaper-details"}
+                                className="w-full"
+                                initial={{ opacity: 0, x: 32 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                exit={{ opacity: 0, x: 32 }}
+                                transition={WALLPAPER_GRID_TRANSITION}
+                            >
+                                {details}
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                </aside>
+            </div>
+        </LayoutGroup>
+    )
+}

--- a/src/renderer/components/wallpaper/wallpaper-grid-shell.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid-shell.tsx
@@ -2,9 +2,8 @@ import { useLayoutEffect, useRef, useState, type Key, type ReactNode } from "rea
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion"
 import { columnsForWidth } from "@/lib/utils"
 import { trpc } from "@/lib/trpc"
-import { DEFAULT_WALLPAPER_GRID_DENSITY } from "../../../shared/constants/grid"
+import { DEFAULT_WALLPAPER_GRID_DENSITY, WALLPAPER_GRID_GAP } from "../../../shared/constants/grid"
 
-const GRID_GAP = 16 // matches gap-4
 const WALLPAPER_DETAILS_MIN_WIDTH = 320 // matches the original Installed w-80 panel
 export const WALLPAPER_GRID_TRANSITION = { duration: 0.3, ease: "easeOut" } as const
 
@@ -48,7 +47,7 @@ export function WallpaperGridShell({ children, details, detailsKey }: WallpaperG
 
     const density = settings?.wallpaperGridDensity ?? DEFAULT_WALLPAPER_GRID_DENSITY
     const gridWidth = reserveDetailsColumn
-        ? Math.max(0, width - WALLPAPER_DETAILS_MIN_WIDTH - GRID_GAP)
+        ? Math.max(0, width - WALLPAPER_DETAILS_MIN_WIDTH - WALLPAPER_GRID_GAP)
         : width
     const gridColumns = columnsForWidth(gridWidth, density)
 
@@ -64,7 +63,7 @@ export function WallpaperGridShell({ children, details, detailsKey }: WallpaperG
                     style={{
                         width: reserveDetailsColumn ? WALLPAPER_DETAILS_MIN_WIDTH : 0,
                         minWidth: reserveDetailsColumn ? WALLPAPER_DETAILS_MIN_WIDTH : 0,
-                        marginLeft: reserveDetailsColumn ? GRID_GAP : 0,
+                        marginLeft: reserveDetailsColumn ? WALLPAPER_GRID_GAP : 0,
                         pointerEvents: hasDetails ? "auto" : "none",
                     }}
                 >

--- a/src/renderer/components/wallpaper/wallpaper-grid.tsx
+++ b/src/renderer/components/wallpaper/wallpaper-grid.tsx
@@ -1,8 +1,9 @@
-import { motion, AnimatePresence } from "framer-motion"
+import { motion } from "framer-motion"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { type Wallpaper } from "./wallpaper-card"
 import { GridHeader } from "./wallpaper-grid-header"
 import { VirtualizedWallpaperGrid } from "./virtualized-wallpaper-grid"
+import { WallpaperGridShell } from "./wallpaper-grid-shell"
 import { AlertCircle, FolderOpen } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWallpaperSearch } from "@/contexts/wallpaper-search-context"
@@ -15,7 +16,6 @@ import { unsubscribedWorkshopIdsAtom } from "@/contexts/atoms/workshop-atoms"
 
 const WallpaperDetails = lazy(() => import("./details-card/wallpaper-details").then(m => ({ default: m.WallpaperDetails })))
 
-// TODO: Fix wallpaper details size so that is consistent width with a column
 export function WallpaperGrid() {
     const { selectedWallpaper, setSelectedWallpaper, toggleWallpaper } = useWallpaperSelection()
     const unsubscribedWorkshopIds = useAtomValue(unsubscribedWorkshopIdsAtom)
@@ -141,8 +141,20 @@ export function WallpaperGrid() {
         <div className="flex flex-col h-full">
             <GridHeader onRefresh={handleRefresh} isLoading={isFetching} />
 
-            <div className="flex items-start gap-6 flex-1">
-                <div className="flex-1 h-fit transition-all duration-300">
+            <WallpaperGridShell
+                detailsKey={selectedWallpaper?.id}
+                details={selectedWallpaper ? (
+                    <Suspense fallback={<Skeleton className="w-full h-96 rounded-xl" />}>
+                        <WallpaperDetails
+                            key={selectedWallpaper.id}
+                            wallpaper={selectedWallpaper}
+                            onClose={() => setSelectedWallpaper(null)}
+                            onUnsubscribe={handleUnsubscribe}
+                        />
+                    </Suspense>
+                ) : null}
+            >
+                {(columns) => (
                     <VirtualizedWallpaperGrid
                         wallpapers={wallpapers}
                         isLoading={isLoading}
@@ -150,6 +162,7 @@ export function WallpaperGrid() {
                         showCompatibilityDot={appSettings?.showCompatibilityDot ?? true}
                         selectedId={selectedWallpaper?.id}
                         onCardClick={toggleWallpaper}
+                        columns={columns}
                         emptyIcon={FolderOpen}
                         emptyMessage="No wallpapers found"
                         emptySubMessage={
@@ -158,30 +171,8 @@ export function WallpaperGrid() {
                                 : "Install wallpapers from Steam Workshop via Wallpaper Engine"
                         }
                     />
-                </div>
-
-                <AnimatePresence mode="wait">
-                    {selectedWallpaper && (
-                        <motion.div
-                            key={selectedWallpaper.id}
-                            className="sticky top-0"
-                            initial={{ opacity: 0, x: -40 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            exit={{ opacity: 0, x: -40 }}
-                            transition={{ duration: 0.3, ease: "easeOut" }}
-                        >
-                            <Suspense fallback={<Skeleton className="w-80 h-96 rounded-xl" />}>
-                                <WallpaperDetails
-                                    key={selectedWallpaper.id}
-                                    wallpaper={selectedWallpaper}
-                                    onClose={() => setSelectedWallpaper(null)}
-                                    onUnsubscribe={handleUnsubscribe}
-                                />
-                            </Suspense>
-                        </motion.div>
-                    )}
-                </AnimatePresence>
-            </div>
+                )}
+            </WallpaperGridShell>
 
         </div>
     )

--- a/src/renderer/components/workshop/workshop-browse-view.tsx
+++ b/src/renderer/components/workshop/workshop-browse-view.tsx
@@ -14,7 +14,7 @@ interface WorkshopBrowseViewProps {
   sortBy: WorkshopSortBy
   selectedId: string | undefined
   onCardClick: (w: Wallpaper) => void
-  gridClassName: string
+  columns: number
 }
 
 export function WorkshopBrowseView({
@@ -22,7 +22,7 @@ export function WorkshopBrowseView({
   sortBy,
   selectedId,
   onCardClick,
-  gridClassName,
+  columns,
 }: WorkshopBrowseViewProps) {
   const [page, setPage] = useState(1)
   const utils = trpc.useUtils()
@@ -53,7 +53,7 @@ export function WorkshopBrowseView({
         showCompatibilityDot={false}
         selectedId={selectedId}
         onCardClick={onCardClick}
-        gridClassName={gridClassName}
+        columns={columns}
         emptyIcon={Store}
         emptyMessage="No workshop items found"
         emptySubMessage="Try a different search term"

--- a/src/renderer/components/workshop/workshop-details-panel.tsx
+++ b/src/renderer/components/workshop/workshop-details-panel.tsx
@@ -1,5 +1,4 @@
 import { Suspense, lazy } from "react"
-import { motion, AnimatePresence } from "framer-motion"
 import { Skeleton } from "@/components/ui/skeleton"
 import type { Wallpaper } from "../../../shared/constants/wallpaper"
 
@@ -8,28 +7,14 @@ const WorkshopWallpaperDetails = lazy(() =>
 )
 
 interface WorkshopDetailsPanelProps {
-  wallpaper: Wallpaper | null
+  wallpaper: Wallpaper
   onClose: () => void
-  onExitComplete: () => void
 }
 
-export function WorkshopDetailsPanel({ wallpaper, onClose, onExitComplete }: WorkshopDetailsPanelProps) {
+export function WorkshopDetailsPanel({ wallpaper, onClose }: WorkshopDetailsPanelProps) {
   return (
-    <AnimatePresence mode="wait" onExitComplete={onExitComplete}>
-      {wallpaper && (
-        <motion.div
-          key={wallpaper.id}
-          className="sticky top-0"
-          initial={{ opacity: 0, x: -40 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -40 }}
-          transition={{ duration: 0.3, ease: "easeOut" }}
-        >
-          <Suspense fallback={<Skeleton className="w-80 h-96 rounded-xl" />}>
-            <WorkshopWallpaperDetails key={wallpaper.id} wallpaper={wallpaper} onClose={onClose} />
-          </Suspense>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <Suspense fallback={<Skeleton className="w-full h-96 rounded-xl" />}>
+      <WorkshopWallpaperDetails wallpaper={wallpaper} onClose={onClose} />
+    </Suspense>
   )
 }

--- a/src/renderer/components/workshop/workshop-discover-section.tsx
+++ b/src/renderer/components/workshop/workshop-discover-section.tsx
@@ -14,7 +14,7 @@ interface WorkshopDiscoverSectionProps {
   onCardClick: (wallpaper: Wallpaper) => void
   onFavoriteToggle: (sectionId: string) => void
   onSeeMore: (sectionId: string) => void
-  gridClassName?: string
+  columns: number
 }
 
 export function WorkshopDiscoverSection({
@@ -27,7 +27,7 @@ export function WorkshopDiscoverSection({
   onCardClick,
   onFavoriteToggle,
   onSeeMore,
-  gridClassName,
+  columns,
 }: WorkshopDiscoverSectionProps) {
   const hasMore = totalResults > wallpapers.length
 
@@ -71,7 +71,7 @@ export function WorkshopDiscoverSection({
         showCompatibilityDot={false}
         selectedId={selectedId}
         onCardClick={onCardClick}
-        gridClassName={gridClassName}
+        columns={columns}
       />
     </motion.section>
   )

--- a/src/renderer/components/workshop/workshop-discover-view.tsx
+++ b/src/renderer/components/workshop/workshop-discover-view.tsx
@@ -14,12 +14,13 @@ import type { Wallpaper } from "../../../shared/constants/wallpaper"
 import type { WorkshopSortBy } from "../../../shared/constants/workshop"
 import { DEFAULT_FAVORITE_DISCOVER_SECTION_IDS } from "../../../shared/constants/workshop"
 import type { RouterOutputs } from "../../../main/trpc/router"
+import {
+  DISCOVER_SECTION_BATCH_SIZE,
+  SKELETON_SECTION_COUNT,
+  SKELETON_CARDS_PER_SECTION,
+} from "../../../shared/constants/grid"
 
 type WorkshopDiscoverSectionData = RouterOutputs["workshop"]["discover"]["sections"][number]
-
-const DISCOVER_SECTION_BATCH_SIZE = 4
-const SKELETON_SECTION_COUNT = 2
-const SKELETON_CARDS_PER_SECTION = 6
 
 interface WorkshopDiscoverViewProps {
   sortBy: WorkshopSortBy

--- a/src/renderer/components/workshop/workshop-discover-view.tsx
+++ b/src/renderer/components/workshop/workshop-discover-view.tsx
@@ -25,14 +25,14 @@ interface WorkshopDiscoverViewProps {
   sortBy: WorkshopSortBy
   selectedId: string | undefined
   onCardClick: (w: Wallpaper) => void
-  gridClassName: string
+  columns: number
 }
 
 export function WorkshopDiscoverView({
   sortBy,
   selectedId,
   onCardClick,
-  gridClassName,
+  columns,
 }: WorkshopDiscoverViewProps) {
   const glass = useGlass()
   const [visibleSectionCount, setVisibleSectionCount] = useState(DISCOVER_SECTION_BATCH_SIZE)
@@ -155,7 +155,10 @@ export function WorkshopDiscoverView({
                 />
               </div>
             </div>
-            <div className={`grid gap-4 ${gridClassName}`}>
+            <div
+              className="grid gap-4"
+              style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+            >
               {Array.from({ length: SKELETON_CARDS_PER_SECTION }).map((__, skeletonIndex) => (
                 <Skeleton key={skeletonIndex} className="aspect-[4/3] rounded-xl" />
               ))}
@@ -191,7 +194,7 @@ export function WorkshopDiscoverView({
           showCompatibilityDot={false}
           selectedId={selectedId}
           onCardClick={onCardClick}
-          gridClassName={gridClassName}
+          columns={columns}
           emptyIcon={Store}
           emptyMessage="No wallpapers in this category"
         />
@@ -218,7 +221,7 @@ export function WorkshopDiscoverView({
         showCompatibilityDot={false}
         selectedId={selectedId}
         onCardClick={onCardClick}
-        gridClassName={gridClassName}
+        columns={columns}
         emptyIcon={Store}
         emptyMessage="No discover categories found"
         emptySubMessage="Try adjusting your workshop filters"
@@ -240,7 +243,7 @@ export function WorkshopDiscoverView({
           onCardClick={onCardClick}
           onFavoriteToggle={onToggleFavoriteSection}
           onSeeMore={onSeeMore}
-          gridClassName={gridClassName}
+          columns={columns}
         />
       ))}
 

--- a/src/renderer/lib/utils.test.ts
+++ b/src/renderer/lib/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { columnsForWidth } from './utils'
+
+describe('columnsForWidth', () => {
+  it.each([
+    ['compact', 630, 3],
+    ['medium', 630, 2],
+    ['large', 630, 1],
+  ] as const)('uses the %s grid density', (density, width, expected) => {
+    expect(columnsForWidth(width, density)).toBe(expected)
+  })
+
+  it('caps the grid at six columns', () => {
+    expect(columnsForWidth(5000, 'compact')).toBe(6)
+  })
+
+  it('always renders at least one column', () => {
+    expect(columnsForWidth(0, 'large')).toBe(1)
+  })
+
+  it('keeps two medium cards beside the details panel at the workshop width', () => {
+    expect(columnsForWidth(464, 'medium')).toBe(2)
+  })
+})

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -1,7 +1,7 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 import { BASE_FPS_OPTIONS } from "../../shared/constants/display"
-import { DEFAULT_WALLPAPER_GRID_DENSITY, WALLPAPER_GRID_MIN_CARD_WIDTH, type WallpaperGridDensity } from "../../shared/constants/grid"
+import { DEFAULT_WALLPAPER_GRID_DENSITY, WALLPAPER_GRID_GAP, MAX_WALLPAPER_GRID_COLUMNS, WALLPAPER_GRID_MIN_CARD_WIDTH, type WallpaperGridDensity } from "../../shared/constants/grid"
 import type { PlaylistTimeUnit } from "../../shared/constants/playlist"
 import { WorkshopItem } from "src/main/services/workshop/workshop.types"
 import { Wallpaper } from "src/shared/constants/wallpaper"
@@ -135,9 +135,6 @@ export function findScrollParent(node: HTMLElement | null): HTMLElement | null {
 }
 
 
-
-const WALLPAPER_GRID_GAP = 16
-const MAX_WALLPAPER_GRID_COLUMNS = 6
 
 export function columnsForWidth(
     width: number,

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 import { BASE_FPS_OPTIONS } from "../../shared/constants/display"
+import { DEFAULT_WALLPAPER_GRID_DENSITY, WALLPAPER_GRID_MIN_CARD_WIDTH, type WallpaperGridDensity } from "../../shared/constants/grid"
 import type { PlaylistTimeUnit } from "../../shared/constants/playlist"
 import { WorkshopItem } from "src/main/services/workshop/workshop.types"
 import { Wallpaper } from "src/shared/constants/wallpaper"
@@ -135,25 +136,16 @@ export function findScrollParent(node: HTMLElement | null): HTMLElement | null {
 
 
 
-// Single source of truth for wallpaper grid column counts. The Tailwind class
-// string styles the static workshop grids directly; columnsForWidth() derives
-// the numeric column count for the virtualized grids from the same string.
-export const DEFAULT_GRID_COLS = "grid-cols-1 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+const WALLPAPER_GRID_GAP = 16
+const MAX_WALLPAPER_GRID_COLUMNS = 6
 
-// Tailwind default breakpoints in px.
-const BREAKPOINTS: Record<string, number> = { sm: 640, md: 768, lg: 1024, xl: 1280, "2xl": 1536 }
-
-export function columnsForWidth(width: number, gridClass: string = DEFAULT_GRID_COLS): number {
-    let cols = 1
-    let matchedMin = -1
-    for (const token of gridClass.split(/\s+/)) {
-        const match = /^(?:(sm|md|lg|xl|2xl):)?grid-cols-(\d+)$/.exec(token)
-        if (!match) continue
-        const minWidth = match[1] ? BREAKPOINTS[match[1]] : 0
-        if (width >= minWidth && minWidth > matchedMin) {
-            matchedMin = minWidth
-            cols = Number(match[2])
-        }
-    }
-    return cols
+export function columnsForWidth(
+    width: number,
+    density: WallpaperGridDensity = DEFAULT_WALLPAPER_GRID_DENSITY,
+): number {
+    const minCardWidth = WALLPAPER_GRID_MIN_CARD_WIDTH[density]
+    return Math.min(
+        MAX_WALLPAPER_GRID_COLUMNS,
+        Math.max(1, Math.floor((width + WALLPAPER_GRID_GAP) / (minCardWidth + WALLPAPER_GRID_GAP))),
+    )
 }

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -9,6 +9,9 @@ import {
     ScanSearch,
     ChevronDown,
     Check,
+    Grid3x3,
+    Grid2x2,
+    Square,
 } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
 import { Input } from "@/components/ui/input"
@@ -20,8 +23,10 @@ import { trpc } from "@/lib/trpc"
 import { useTheme } from "@/components/theme-provider"
 import { THEME_OPTIONS } from "../../shared/constants/theme"
 import { SCALING_OPTIONS } from "../../shared/constants/display"
+import { WALLPAPER_GRID_DENSITY_OPTIONS } from "../../shared/constants/grid"
+import type { WallpaperGridDensity } from "../../shared/constants/grid"
 import type { AppSettings } from "../../shared/constants/app"
-import { getFpsOptions } from "@/lib/utils"
+import { getFpsOptions, cn } from "@/lib/utils"
 import { CompatibilityScanRow } from "@/components/settings/compatibility-scan-row"
 import { LoadingButton } from "@/components/loading-button"
 import { PageHeader } from "@/components/page-header"
@@ -36,6 +41,12 @@ const windowGeometrySchema = z.object({
     windowGeometry: z.string().trim().refine((value) => !value || /^[1-9]\d*x[1-9]\d*$/.test(value), "Use widthxheight, for example 800x600"),
 })
 type WindowGeometryForm = z.infer<typeof windowGeometrySchema>
+
+const DENSITY_ICONS: Record<WallpaperGridDensity, typeof Grid3x3> = {
+    compact: Grid3x3,
+    medium: Grid2x2,
+    large: Square,
+}
 
 export const Route = createFileRoute("/settings")({
     component: SettingsPage,
@@ -380,6 +391,30 @@ function SettingsPage() {
                             checked={settings.showCompatibilityDot}
                             onCheckedChange={(checked) => updateSetting("showCompatibilityDot", checked)}
                         />
+                    </SettingRow>
+                    <SettingRow label="Grid size">
+                        <div role="radiogroup" aria-label="Grid size" className="inline-flex items-center gap-0.5">
+                            {WALLPAPER_GRID_DENSITY_OPTIONS.map(({ label, value }) => {
+                                const Icon = DENSITY_ICONS[value]
+                                const selected = settings.wallpaperGridDensity === value
+                                return (
+                                    <button
+                                        key={value}
+                                        type="button"
+                                        role="radio"
+                                        aria-checked={selected}
+                                        title={label}
+                                        onClick={() => updateSetting("wallpaperGridDensity", value)}
+                                        className={cn(
+                                            "inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                                            selected && "bg-accent text-accent-foreground",
+                                        )}
+                                    >
+                                        <Icon className="size-4" />
+                                    </button>
+                                )
+                            })}
+                        </div>
                     </SettingRow>
                     <SettingRow label="Show status bar">
                         <Switch

--- a/src/renderer/routes/workshop.tsx
+++ b/src/renderer/routes/workshop.tsx
@@ -6,6 +6,7 @@ import { WorkshopToolbar } from "@/components/workshop/workshop-toolbar"
 import { WorkshopBrowseView } from "@/components/workshop/workshop-browse-view"
 import { WorkshopDiscoverView } from "@/components/workshop/workshop-discover-view"
 import { WorkshopDetailsPanel } from "@/components/workshop/workshop-details-panel"
+import { WallpaperGridShell } from "@/components/wallpaper/wallpaper-grid-shell"
 import { ScrollToTopButton } from "@/components/scroll-to-top-button"
 import { RefreshButton } from "@/components/wallpaper/refresh-button"
 import { useDebouncedWorkshopSearchQuery, useWorkshopFilter, useWorkshopSort } from "@/contexts/workshop-search-context"
@@ -22,7 +23,6 @@ function WorkshopPage() {
   const { selectedWallpaper, setSelectedWallpaper, toggleWallpaper } = useWallpaperSelection()
   const [mode, setMode] = useAtom(workshopModeAtom)
   const { sortBy: workshopSortBy } = useWorkshopSort()
-  const [detailsVisible, setDetailsVisible] = useState(false)
   const { debouncedSearchQuery } = useDebouncedWorkshopSearchQuery()
   const { filterType, filterAgeRating, filterTags, filterResolution } = useWorkshopFilter()
   const { setSelectedUrl } = useWallpaperBackground()
@@ -36,12 +36,6 @@ function WorkshopPage() {
   useEffect(() => {
     setSelectedUrl(selectedWallpaper?.thumbnail ?? null)
   }, [selectedWallpaper, setSelectedUrl])
-
-  // Shrink grid immediately when a wallpaper is selected; the false flip is
-  // deferred to onExitComplete so columns expand only after the panel exits.
-  useEffect(() => {
-    if (selectedWallpaper) setDetailsVisible(true)
-  }, [selectedWallpaper])
 
   trpc.workshop.onConnectionEvent.useSubscription(undefined, {
     onData: () => {
@@ -59,10 +53,6 @@ function WorkshopPage() {
     filterResolution.join(","),
     workshopSortBy,
   ].join("|")
-
-  const gridCols = detailsVisible
-    ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
-    : "grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
 
   const handleRefresh = async () => {
     setIsRefreshing(true)
@@ -89,38 +79,38 @@ function WorkshopPage() {
         />
       </PageHeader>
 
-      <div className="flex items-start gap-6 flex-1">
-        <div className="flex-1 h-fit transition-all duration-300 space-y-4">
-          {showBrowse ? (
-            <WorkshopBrowseView
-              key={viewKey}
-              searchQuery={debouncedSearchQuery}
-              sortBy={workshopSortBy}
-              selectedId={selectedWallpaper?.id}
-              onCardClick={toggleWallpaper}
-              gridClassName={gridCols}
-            />
-          ) : (
-            <WorkshopDiscoverView
-              key={viewKey}
-              sortBy={workshopSortBy}
-              selectedId={selectedWallpaper?.id}
-              onCardClick={toggleWallpaper}
-              gridClassName={gridCols}
-            />
-          )}
-        </div>
-
-        <WorkshopDetailsPanel
-          wallpaper={selectedWallpaper}
-          onClose={() => setSelectedWallpaper(null)}
-          onExitComplete={() => {
-            // Only collapse columns when the panel is fully gone. When switching
-            // between cards the exit fires too, but a selection still exists.
-            if (!selectedWallpaper) setDetailsVisible(false)
-          }}
-        />
-      </div>
+      <WallpaperGridShell
+        detailsKey={selectedWallpaper?.id}
+        details={selectedWallpaper ? (
+          <WorkshopDetailsPanel
+            wallpaper={selectedWallpaper}
+            onClose={() => setSelectedWallpaper(null)}
+          />
+        ) : null}
+      >
+        {(columns) => (
+          <div className="space-y-4">
+            {showBrowse ? (
+              <WorkshopBrowseView
+                key={viewKey}
+                searchQuery={debouncedSearchQuery}
+                sortBy={workshopSortBy}
+                selectedId={selectedWallpaper?.id}
+                onCardClick={toggleWallpaper}
+                columns={columns}
+              />
+            ) : (
+              <WorkshopDiscoverView
+                key={viewKey}
+                sortBy={workshopSortBy}
+                selectedId={selectedWallpaper?.id}
+                onCardClick={toggleWallpaper}
+                columns={columns}
+              />
+            )}
+          </div>
+        )}
+      </WallpaperGridShell>
       <ScrollToTopButton />
     </div>
   )

--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -2,6 +2,7 @@ import type { CompatibilityStatus } from './compatibility'
 import type { ScalingOption } from './display'
 import type { SortBy, SortOrder } from './sort'
 import type { ThemeOption } from './theme'
+import { DEFAULT_WALLPAPER_GRID_DENSITY, type WallpaperGridDensity } from './grid'
 import { DEFAULT_FAVORITE_DISCOVER_SECTION_IDS, type WorkshopSortBy } from './workshop'
 import type { AgeRating, WallpaperFilterType } from './wallpaper'
 import packageJson from '../../../package.json'
@@ -39,6 +40,7 @@ export interface AppSettings {
   showCompatibilityDot: boolean
   showStatusBar: boolean
   dynamicBackground: boolean
+  wallpaperGridDensity: WallpaperGridDensity
   dismissedScanReminder: boolean
   dismissedUpdateVersion: string | null
 
@@ -98,6 +100,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   showCompatibilityDot: true,
   showStatusBar: true,
   dynamicBackground: true,
+  wallpaperGridDensity: DEFAULT_WALLPAPER_GRID_DENSITY,
   dismissedScanReminder: false,
   dismissedUpdateVersion: null,
 

--- a/src/shared/constants/grid.ts
+++ b/src/shared/constants/grid.ts
@@ -16,3 +16,13 @@ export const WALLPAPER_GRID_DENSITY_OPTIONS: ReadonlyArray<{
 ]
 
 export const DEFAULT_WALLPAPER_GRID_DENSITY: WallpaperGridDensity = 'medium'
+
+export const WALLPAPER_GRID_SKELETON_COUNT = 20
+
+export const WALLPAPER_GRID_GAP = 16
+
+export const MAX_WALLPAPER_GRID_COLUMNS = 6
+
+export const DISCOVER_SECTION_BATCH_SIZE = 4
+export const SKELETON_SECTION_COUNT = 2
+export const SKELETON_CARDS_PER_SECTION = 6

--- a/src/shared/constants/grid.ts
+++ b/src/shared/constants/grid.ts
@@ -1,0 +1,18 @@
+export const WALLPAPER_GRID_MIN_CARD_WIDTH = {
+  compact: 160,
+  medium: 200,
+  large: 320,
+} as const
+
+export type WallpaperGridDensity = keyof typeof WALLPAPER_GRID_MIN_CARD_WIDTH
+
+export const WALLPAPER_GRID_DENSITY_OPTIONS: ReadonlyArray<{
+  label: string
+  value: WallpaperGridDensity
+}> = [
+  { label: 'Compact', value: 'compact' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Large', value: 'large' },
+]
+
+export const DEFAULT_WALLPAPER_GRID_DENSITY: WallpaperGridDensity = 'medium'


### PR DESCRIPTION
## Summary

- Unify Installed and Workshop wallpaper grids with a shared responsive shell.
- Add compact, medium, and large wallpaper grid density settings.
- Animate grid reflows and details-panel transitions consistently.
- Update virtualized grids, playlist grids, and workshop views to use shared column sizing.
- Add coverage for density-based column calculations and settings behavior.

## Testing

- Added Vitest coverage for responsive grid column calculations.
- Updated settings route tests to cover wallpaper grid density.
- Not run locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagrat7/linux-wallpaper-engine/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Appearance settings for compact, medium, or large wallpaper grid sizes.
  * Wallpaper grids now adapt column counts to available space and selected density.
  * Added animated transitions when grid layouts change.
  * Improved wallpaper details panel layout and responsive sizing.

* **Bug Fixes**
  * Preserved selected grid density without unnecessarily reapplying wallpapers.
  * Improved loading behavior with consistent grid placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes responsive wallpaper-grid behavior and adds a persisted density preference shared across Installed, Workshop, and playlist views.
- Adds compact, medium, and large density options with width-based column calculation.
- Introduces a shared grid-and-details-panel shell with coordinated layout transitions.
- Updates static and virtualized grids to consume numeric column counts and shared constants.
- Extends settings validation and tests for the new preference.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/renderer/components/wallpaper/wallpaper-grid-shell.tsx | Introduces the shared responsive shell that measures available width, reserves details-panel space, and coordinates transitions. |
| src/renderer/components/wallpaper/virtualized-wallpaper-grid.tsx | Updates virtualization to use density-aware or caller-supplied columns, shared dimensions, and animated card layouts. |
| src/renderer/components/wallpaper/wallpaper-grid-layout.tsx | Converts static wallpaper grids to numeric responsive columns and memoized animated card items. |
| src/renderer/lib/utils.ts | Replaces Tailwind-class parsing with a direct density-based column calculation capped at six columns. |
| src/renderer/routes/settings.tsx | Adds the accessible compact, medium, and large grid-size selector. |
| src/main/trpc/routes/settings.ts | Extends settings input validation to accept the wallpaper-grid density preference. |
| src/shared/constants/grid.ts | Centralizes density definitions, grid dimensions, limits, and loading-placeholder counts. |
| src/renderer/routes/workshop.tsx | Migrates Workshop browse and discovery layouts to the shared grid shell and details panel. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Settings[Grid density setting] --> Shell[WallpaperGridShell]
    Shell --> Width[Measure available width]
    Width --> Columns[columnsForWidth]
    Settings --> Columns
    Columns --> Installed[Installed virtualized grid]
    Columns --> Workshop[Workshop grids]
    Settings --> Playlist[Playlist virtualized grid]
    Shell --> Details[Animated details panel]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Optimize wallpaper grid rendering with m..."](https://github.com/jagrat7/linux-wallpaper-engine/commit/a3df5e2b4c956944aea66a8c9dd9104333542799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59669911)</sub>

<!-- /greptile_comment -->