### PR TITLE
Support vanilla Hyprland theme paths

### DIFF
--- a/src/main/services/system-theme/providers/hyprland.test.ts
+++ b/src/main/services/system-theme/providers/hyprland.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getHyprlandWatchPaths,
+  getPywalThemePaths,
+  getVanillaHyprlandPaths,
+  parseHyprlandTheme,
+  parseKeyValueTheme,
+} from './hyprland'
+
+describe('hyprland theme paths', () => {
+  it('watches pywal then vanilla Hyprland config files', () => {
+    expect(getPywalThemePaths('/home/user')).toEqual([
+      '/home/user/.cache/wal/colors.sh',
+    ])
+    expect(getVanillaHyprlandPaths('/home/user')).toEqual([
+      '/home/user/.config/hypr/hyprland.conf',
+      '/home/user/.config/hypr/colors.conf',
+    ])
+    expect(getHyprlandWatchPaths('/home/user')).toEqual([
+      '/home/user/.cache/wal/colors.sh',
+      '/home/user/.config/hypr/hyprland.conf',
+      '/home/user/.config/hypr/colors.conf',
+    ])
+  })
+})
+
+describe('parseKeyValueTheme', () => {
+  it('parses a pywal colors.sh palette', () => {
+    const theme = parseKeyValueTheme(`
+wallpaper='/home/user/pic.png'
+foreground='#cdd6f4'
+background='#1e1e2e'
+cursor='#cdd6f4'
+color0='#313244'
+color1='#f38ba8'
+color2='#a6e3a1'
+color3='#f9e2af'
+color4='#89b4fa'
+color7='#bac2de'
+color8='#585b70'
+color15='#cdd6f4'
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      background: '#1e1e2e',
+      foreground: '#cdd6f4',
+      card: '#313244',
+      primary: '#89b4fa',
+      mutedForeground: '#bac2de',
+      destructive: '#f38ba8',
+      success: '#a6e3a1',
+      warning: '#f9e2af',
+    }))
+  })
+})
+
+describe('parseHyprlandTheme', () => {
+  it('uses a semantic Lua color table when one is available', () => {
+    const theme = parseHyprlandTheme(`
+local colors = {
+  background = "302270",
+  surface = "3a2b80",
+  surface_alt = "4c39a0",
+  border = "9368bf",
+  accent = "898efa",
+  foreground = "86f3f5",
+}
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      background: '#302270',
+      foreground: '#86f3f5',
+      card: '#3a2b80',
+      primary: '#898efa',
+      accent: '#4c39a0',
+      border: '#9368bf',
+      sidebarPrimary: 'color-mix(in oklch, #898efa 22%, #302270)',
+      sidebarAccent: '#4c39a0',
+    }))
+  })
+
+  it('falls back to Lua border colors and gradients', () => {
+    const theme = parseHyprlandTheme(`
+local active_border_color = { colors = { "rgba(8a8588ee)", "rgba(e2dddcee)" }, angle = 45 }
+local inactive_border_color = "rgba(584e51aa)"
+
+hl.config({
+  general = { col = {
+    active_border = active_border_color,
+    inactive_border = inactive_border_color,
+  } },
+})
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      primary: '#8a8588',
+      primaryForeground: '#000000',
+      accent: '#584e51',
+      border: '#584e51',
+      sidebarPrimary: 'color-mix(in oklch, #8a8588 22%, var(--sidebar))',
+      sidebarAccent: '#584e51',
+    }))
+  })
+
+  it('parses vanilla hyprland.conf border colors', () => {
+    const theme = parseHyprlandTheme(`
+general {
+    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.inactive_border = rgba(595959aa)
+}
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      primary: '#33ccff',
+      primaryForeground: '#000000',
+      accent: '#595959',
+      border: '#595959',
+      sidebarPrimary: 'color-mix(in oklch, #33ccff 22%, var(--sidebar))',
+      sidebarAccent: '#595959',
+    }))
+  })
+
+  it('rejects Lua without usable colors', () => {
+    expect(parseHyprlandTheme('hl.config({ decoration = { rounding = 8 } })')).toBeNull()
+  })
+})

--- a/src/main/services/system-theme/providers/hyprland.ts
+++ b/src/main/services/system-theme/providers/hyprland.ts
@@ -1,0 +1,187 @@
+import { homedir } from 'node:os'
+import path from 'node:path'
+import type { DesktopThemeProvider, SystemThemePalette } from '../system-theme.types'
+import { inferScheme, readText, subtleSidebarColor } from '../system-theme.utils'
+
+const HEX_COLOR_PATTERN = /^#[\da-f]{6}(?:[\da-f]{2})?$/i
+
+export const getVanillaHyprlandPaths = (homeDirectory: string): string[] => [
+  path.join(homeDirectory, '.config/hypr/hyprland.conf'),
+  path.join(homeDirectory, '.config/hypr/colors.conf'),
+]
+
+export const getPywalThemePaths = (homeDirectory: string): string[] => [
+  path.join(homeDirectory, '.cache/wal/colors.sh'),
+]
+
+export const getHyprlandWatchPaths = (homeDirectory: string): string[] => [
+  ...getPywalThemePaths(homeDirectory),
+  ...getVanillaHyprlandPaths(homeDirectory),
+]
+
+const PYWAL_THEME_PATHS = getPywalThemePaths(homedir())
+const VANILLA_HYPRLAND_PATHS = getVanillaHyprlandPaths(homedir())
+const HYPRLAND_WATCH_PATHS = getHyprlandWatchPaths(homedir())
+
+export const parseKeyValueTheme = (source: string): SystemThemePalette | null => {
+  const colors = Object.fromEntries(Array.from(source.matchAll(
+    /^\s*([\w]+)\s*=\s*["']([^"']+)["']/gm,
+  )).filter(([, , value]) => HEX_COLOR_PATTERN.test(value)).map(([, key, value]) => [
+    key,
+    value,
+  ])) as Record<string, string>
+
+  if (colors.background === undefined || colors.foreground === undefined) return null
+  const accent = colors.accent ?? colors.blue ?? colors.color4
+  const selection = colors.selection ?? colors.selection_background ?? accent
+  const selectionForeground = colors.selection_foreground
+    ?? colors.bright_foreground
+    ?? colors.color15
+    ?? colors.foreground
+  const surface = colors.lighter_background
+    ?? colors.color0
+    ?? colors.dark_background
+    ?? colors.background
+  const mutedForeground = colors.muted
+    ?? colors.dark_foreground
+    ?? colors.color7
+    ?? colors.color8
+    ?? colors.foreground
+  return {
+    background: colors.background,
+    foreground: colors.foreground,
+    card: surface,
+    cardForeground: colors.foreground,
+    primary: accent,
+    primaryForeground: colors.background,
+    secondary: surface,
+    secondaryForeground: colors.foreground,
+    muted: surface,
+    mutedForeground,
+    accent: selection,
+    accentForeground: selectionForeground,
+    destructive: colors.red ?? colors.color1,
+    border: colors.muted ?? colors.color8,
+    input: surface,
+    success: colors.green ?? colors.color2,
+    warning: colors.yellow ?? colors.color3,
+    ring: accent,
+    sidebar: colors.background,
+    sidebarForeground: colors.foreground,
+    sidebarPrimary: subtleSidebarColor(accent, colors.background),
+    sidebarPrimaryForeground: colors.foreground,
+    sidebarAccent: selection,
+    sidebarAccentForeground: selectionForeground,
+    sidebarBorder: colors.muted ?? colors.color8,
+    sidebarRing: accent,
+  }
+}
+
+const parseHyprColor = (value: string | undefined): string | undefined => {
+  if (value === undefined) return undefined
+  const match = value.match(/#([\da-f]{6})(?:[\da-f]{2})?/i)
+    ?? value.match(/rgba?\(\s*([\da-f]{6})(?:[\da-f]{2})?\s*\)/i)
+    ?? value.match(/^\s*["']?([\da-f]{6})(?:[\da-f]{2})?["']?\s*$/i)
+  return match === null ? undefined : `#${match[1]}`
+}
+
+const findLuaVariableColor = (source: string, names: string[]): string | undefined => {
+  for (const name of names) {
+    const declaration = source.match(new RegExp(`\\blocal\\s+${name}\\s*=`, 'i'))
+    if (declaration?.index === undefined) continue
+    const start = declaration.index + declaration[0].length
+    const end = source.slice(start).search(/\n\s*(?:local\s+|hl\.|o\.)/)
+    const expression = source.slice(start, end < 0 ? undefined : start + end)
+    const color = parseHyprColor(expression)
+    if (color !== undefined) return color
+  }
+  return undefined
+}
+
+const findLuaAssignedColor = (source: string, keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const assignment = source.match(new RegExp(`(?:\\[\"${key.replace('.', '\\.') }\"\\]|\\b${key.replace('.', '\\.')})\\s*=\\s*([^,\\n}]+)`, 'i'))
+    if (assignment === null) continue
+    const direct = parseHyprColor(assignment[1])
+    if (direct !== undefined) return direct
+    const variable = assignment[1].trim().match(/^([\w]+)$/)?.[1]
+    if (variable !== undefined) {
+      const resolved = findLuaVariableColor(source, [variable])
+      if (resolved !== undefined) return resolved
+    }
+    const fromTable = parseHyprColor(source.slice(assignment.index, (assignment.index ?? 0) + 500))
+    if (fromTable !== undefined) return fromTable
+  }
+  return undefined
+}
+
+export const parseHyprlandTheme = (source: string): SystemThemePalette | null => {
+  const namedColors = Object.fromEntries(Array.from(source.matchAll(
+    /^\s*(background|bg|surface|surface_alt|foreground|fg|accent|active|border|muted)\s*=\s*["']([^"']+)["']/gim,
+  )).map(([, key, value]) => [key.toLowerCase(), parseHyprColor(value)]).filter((entry): entry is [string, string] => entry[1] !== undefined))
+
+  const background = namedColors.background ?? namedColors.bg
+  const foreground = namedColors.foreground ?? namedColors.fg
+  const activeBorder = namedColors.accent
+    ?? namedColors.active
+    ?? findLuaVariableColor(source, ['active_border_color', 'activeBorderColor'])
+    ?? findLuaAssignedColor(source, ['col.active_border', 'active_border', 'border_active'])
+  const inactiveBorder = namedColors.border
+    ?? namedColors.muted
+    ?? findLuaVariableColor(source, ['inactive_border_color', 'inactiveBorderColor'])
+    ?? findLuaAssignedColor(source, ['col.inactive_border', 'inactive_border', 'border_inactive'])
+  const surface = namedColors.surface ?? background
+  const selection = namedColors.surface_alt ?? inactiveBorder ?? surface
+
+  if (background === undefined && foreground === undefined
+    && activeBorder === undefined && inactiveBorder === undefined) return null
+
+  const activeForeground = background
+    ?? (inferScheme(activeBorder) === 'light' ? '#000000' : '#ffffff')
+  return {
+    background,
+    foreground,
+    card: surface,
+    cardForeground: foreground,
+    primary: activeBorder,
+    primaryForeground: activeForeground,
+    secondary: surface,
+    secondaryForeground: foreground,
+    muted: surface,
+    mutedForeground: foreground,
+    accent: selection,
+    accentForeground: foreground,
+    border: inactiveBorder,
+    input: surface,
+    ring: activeBorder,
+    sidebar: background,
+    sidebarForeground: foreground,
+    sidebarPrimary: subtleSidebarColor(activeBorder, background),
+    sidebarPrimaryForeground: foreground,
+    sidebarAccent: selection,
+    sidebarAccentForeground: foreground,
+    sidebarBorder: inactiveBorder,
+    sidebarRing: activeBorder,
+  }
+}
+
+export const readFirstPalette = (
+  filePaths: readonly string[],
+  parse: (source: string) => SystemThemePalette | null,
+): SystemThemePalette | null => {
+  for (const filePath of filePaths) {
+    const source = readText(filePath)
+    if (source === null) continue
+    const theme = parse(source)
+    if (theme !== null) return theme
+  }
+  return null
+}
+
+export const hyprlandThemeProvider = {
+  matches: (desktop: string) => desktop.includes('hyprland'),
+  watchPaths: HYPRLAND_WATCH_PATHS,
+  readPalette: () =>
+    readFirstPalette(PYWAL_THEME_PATHS, parseKeyValueTheme)
+    ?? readFirstPalette(VANILLA_HYPRLAND_PATHS, parseHyprlandTheme),
+} satisfies DesktopThemeProvider

--- a/src/main/services/system-theme/providers/index.ts
+++ b/src/main/services/system-theme/providers/index.ts
@@ -1,5 +1,6 @@
 import type { DesktopThemeProvider } from '../system-theme.types'
 import { cosmicThemeProvider } from './cosmic'
+import { hyprlandThemeProvider } from './hyprland'
 import { kdeThemeProvider } from './kde'
 import { omarchyThemeProvider } from './omarchy'
 
@@ -7,4 +8,5 @@ export const desktopThemeProviders = [
   cosmicThemeProvider,
   kdeThemeProvider,
   omarchyThemeProvider,
+  hyprlandThemeProvider,
 ] satisfies DesktopThemeProvider[]

--- a/src/main/services/system-theme/providers/omarchy.test.ts
+++ b/src/main/services/system-theme/providers/omarchy.test.ts
@@ -3,12 +3,14 @@ import {
   getOmarchyHyprlandPaths,
   getOmarchyThemePaths,
   getOmarchyWatchPaths,
+  getPywalThemePaths,
+  getVanillaHyprlandPaths,
   parseOmarchyHyprlandTheme,
   parseOmarchyTheme,
 } from './omarchy'
 
 describe('getOmarchyThemePaths', () => {
-  it('prefers current Omarchy state and falls back to its legacy config path', () => {
+  it('prefers current Omarchy state and falls back to vanilla Hyprland and pywal paths', () => {
     expect(getOmarchyThemePaths('/home/user')).toEqual([
       '/home/user/.local/state/omarchy/current/theme/colors.toml',
       '/home/user/.config/omarchy/current/theme/colors.toml',
@@ -17,11 +19,21 @@ describe('getOmarchyThemePaths', () => {
       '/home/user/.local/state/omarchy/current/theme/hyprland.lua',
       '/home/user/.config/omarchy/current/theme/hyprland.lua',
     ])
+    expect(getPywalThemePaths('/home/user')).toEqual([
+      '/home/user/.cache/wal/colors.sh',
+    ])
+    expect(getVanillaHyprlandPaths('/home/user')).toEqual([
+      '/home/user/.config/hypr/hyprland.conf',
+      '/home/user/.config/hypr/colors.conf',
+    ])
     expect(getOmarchyWatchPaths('/home/user')).toEqual([
       '/home/user/.local/state/omarchy/current/theme/colors.toml',
       '/home/user/.config/omarchy/current/theme/colors.toml',
       '/home/user/.local/state/omarchy/current/theme/hyprland.lua',
       '/home/user/.config/omarchy/current/theme/hyprland.lua',
+      '/home/user/.cache/wal/colors.sh',
+      '/home/user/.config/hypr/hyprland.conf',
+      '/home/user/.config/hypr/colors.conf',
       '/home/user/.local/state/omarchy/current/theme.name',
     ])
   })
@@ -63,6 +75,34 @@ green = "#4a2fd0"
       destructive: '#c900c4',
       success: '#4a2fd0',
       warning: '#026fde',
+    }))
+  })
+
+  it('parses a pywal colors.sh palette', () => {
+    const theme = parseOmarchyTheme(`
+wallpaper='/home/user/pic.png'
+foreground='#cdd6f4'
+background='#1e1e2e'
+cursor='#cdd6f4'
+color0='#313244'
+color1='#f38ba8'
+color2='#a6e3a1'
+color3='#f9e2af'
+color4='#89b4fa'
+color7='#bac2de'
+color8='#585b70'
+color15='#cdd6f4'
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      background: '#1e1e2e',
+      foreground: '#cdd6f4',
+      card: '#313244',
+      primary: '#89b4fa',
+      mutedForeground: '#bac2de',
+      destructive: '#f38ba8',
+      success: '#a6e3a1',
+      warning: '#f9e2af',
     }))
   })
 
@@ -141,6 +181,24 @@ hl.config({
       border: '#584e51',
       sidebarPrimary: 'color-mix(in oklch, #8a8588 22%, var(--sidebar))',
       sidebarAccent: '#584e51',
+    }))
+  })
+
+  it('parses vanilla hyprland.conf border colors', () => {
+    const theme = parseOmarchyHyprlandTheme(`
+general {
+    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.inactive_border = rgba(595959aa)
+}
+`)
+
+    expect(theme).toEqual(expect.objectContaining({
+      primary: '#33ccff',
+      primaryForeground: '#000000',
+      accent: '#595959',
+      border: '#595959',
+      sidebarPrimary: 'color-mix(in oklch, #33ccff 22%, var(--sidebar))',
+      sidebarAccent: '#595959',
     }))
   })
 

--- a/src/main/services/system-theme/providers/omarchy.test.ts
+++ b/src/main/services/system-theme/providers/omarchy.test.ts
@@ -3,14 +3,11 @@ import {
   getOmarchyHyprlandPaths,
   getOmarchyThemePaths,
   getOmarchyWatchPaths,
-  getPywalThemePaths,
-  getVanillaHyprlandPaths,
-  parseOmarchyHyprlandTheme,
   parseOmarchyTheme,
 } from './omarchy'
 
 describe('getOmarchyThemePaths', () => {
-  it('prefers current Omarchy state and falls back to vanilla Hyprland and pywal paths', () => {
+  it('uses Omarchy theme files and the Hyprland child for everything else', () => {
     expect(getOmarchyThemePaths('/home/user')).toEqual([
       '/home/user/.local/state/omarchy/current/theme/colors.toml',
       '/home/user/.config/omarchy/current/theme/colors.toml',
@@ -19,21 +16,11 @@ describe('getOmarchyThemePaths', () => {
       '/home/user/.local/state/omarchy/current/theme/hyprland.lua',
       '/home/user/.config/omarchy/current/theme/hyprland.lua',
     ])
-    expect(getPywalThemePaths('/home/user')).toEqual([
-      '/home/user/.cache/wal/colors.sh',
-    ])
-    expect(getVanillaHyprlandPaths('/home/user')).toEqual([
-      '/home/user/.config/hypr/hyprland.conf',
-      '/home/user/.config/hypr/colors.conf',
-    ])
     expect(getOmarchyWatchPaths('/home/user')).toEqual([
       '/home/user/.local/state/omarchy/current/theme/colors.toml',
       '/home/user/.config/omarchy/current/theme/colors.toml',
       '/home/user/.local/state/omarchy/current/theme/hyprland.lua',
       '/home/user/.config/omarchy/current/theme/hyprland.lua',
-      '/home/user/.cache/wal/colors.sh',
-      '/home/user/.config/hypr/hyprland.conf',
-      '/home/user/.config/hypr/colors.conf',
       '/home/user/.local/state/omarchy/current/theme.name',
     ])
   })
@@ -78,34 +65,6 @@ green = "#4a2fd0"
     }))
   })
 
-  it('parses a pywal colors.sh palette', () => {
-    const theme = parseOmarchyTheme(`
-wallpaper='/home/user/pic.png'
-foreground='#cdd6f4'
-background='#1e1e2e'
-cursor='#cdd6f4'
-color0='#313244'
-color1='#f38ba8'
-color2='#a6e3a1'
-color3='#f9e2af'
-color4='#89b4fa'
-color7='#bac2de'
-color8='#585b70'
-color15='#cdd6f4'
-`)
-
-    expect(theme).toEqual(expect.objectContaining({
-      background: '#1e1e2e',
-      foreground: '#cdd6f4',
-      card: '#313244',
-      primary: '#89b4fa',
-      mutedForeground: '#bac2de',
-      destructive: '#f38ba8',
-      success: '#a6e3a1',
-      warning: '#f9e2af',
-    }))
-  })
-
   it('keeps compatibility with the legacy Omarchy ANSI palette', () => {
     const theme = parseOmarchyTheme(`
 background = "#1e1e2e"
@@ -133,76 +92,5 @@ color8 = "#585b70"
 
   it('rejects an incomplete palette', () => {
     expect(parseOmarchyTheme('accent = "#89b4fa"')).toBeNull()
-  })
-})
-
-describe('parseOmarchyHyprlandTheme', () => {
-  it('uses a semantic Lua color table when one is available', () => {
-    const theme = parseOmarchyHyprlandTheme(`
-local colors = {
-  background = "302270",
-  surface = "3a2b80",
-  surface_alt = "4c39a0",
-  border = "9368bf",
-  accent = "898efa",
-  foreground = "86f3f5",
-}
-`)
-
-    expect(theme).toEqual(expect.objectContaining({
-      background: '#302270',
-      foreground: '#86f3f5',
-      card: '#3a2b80',
-      primary: '#898efa',
-      accent: '#4c39a0',
-      border: '#9368bf',
-      sidebarPrimary: 'color-mix(in oklch, #898efa 22%, #302270)',
-      sidebarAccent: '#4c39a0',
-    }))
-  })
-
-  it('falls back to Lua border colors and gradients', () => {
-    const theme = parseOmarchyHyprlandTheme(`
-local active_border_color = { colors = { "rgba(8a8588ee)", "rgba(e2dddcee)" }, angle = 45 }
-local inactive_border_color = "rgba(584e51aa)"
-
-hl.config({
-  general = { col = {
-    active_border = active_border_color,
-    inactive_border = inactive_border_color,
-  } },
-})
-`)
-
-    expect(theme).toEqual(expect.objectContaining({
-      primary: '#8a8588',
-      primaryForeground: '#000000',
-      accent: '#584e51',
-      border: '#584e51',
-      sidebarPrimary: 'color-mix(in oklch, #8a8588 22%, var(--sidebar))',
-      sidebarAccent: '#584e51',
-    }))
-  })
-
-  it('parses vanilla hyprland.conf border colors', () => {
-    const theme = parseOmarchyHyprlandTheme(`
-general {
-    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
-    col.inactive_border = rgba(595959aa)
-}
-`)
-
-    expect(theme).toEqual(expect.objectContaining({
-      primary: '#33ccff',
-      primaryForeground: '#000000',
-      accent: '#595959',
-      border: '#595959',
-      sidebarPrimary: 'color-mix(in oklch, #33ccff 22%, var(--sidebar))',
-      sidebarAccent: '#595959',
-    }))
-  })
-
-  it('rejects Lua without usable colors', () => {
-    expect(parseOmarchyHyprlandTheme('hl.config({ decoration = { rounding = 8 } })')).toBeNull()
   })
 })

--- a/src/main/services/system-theme/providers/omarchy.ts
+++ b/src/main/services/system-theme/providers/omarchy.ts
@@ -16,9 +16,20 @@ export const getOmarchyHyprlandPaths = (homeDirectory: string): string[] => [
   path.join(homeDirectory, '.config/omarchy/current/theme/hyprland.lua'),
 ]
 
+export const getVanillaHyprlandPaths = (homeDirectory: string): string[] => [
+  path.join(homeDirectory, '.config/hypr/hyprland.conf'),
+  path.join(homeDirectory, '.config/hypr/colors.conf'),
+]
+
+export const getPywalThemePaths = (homeDirectory: string): string[] => [
+  path.join(homeDirectory, '.cache/wal/colors.sh'),
+]
+
 export const getOmarchyWatchPaths = (homeDirectory: string): string[] => [
   ...getOmarchyThemePaths(homeDirectory),
   ...getOmarchyHyprlandPaths(homeDirectory),
+  ...getPywalThemePaths(homeDirectory),
+  ...getVanillaHyprlandPaths(homeDirectory),
   // Theme switches replace the entire current/theme directory, then update this
   // marker in its stable parent directory.
   path.join(homeDirectory, '.local/state/omarchy/current/theme.name'),
@@ -26,6 +37,8 @@ export const getOmarchyWatchPaths = (homeDirectory: string): string[] => [
 
 const OMARCHY_THEME_PATHS = getOmarchyThemePaths(homedir())
 const OMARCHY_HYPRLAND_PATHS = getOmarchyHyprlandPaths(homedir())
+const PYWAL_THEME_PATHS = getPywalThemePaths(homedir())
+const VANILLA_HYPRLAND_PATHS = getVanillaHyprlandPaths(homedir())
 const OMARCHY_WATCH_PATHS = getOmarchyWatchPaths(homedir())
 
 export const parseOmarchyTheme = (source: string): SystemThemePalette | null => {
@@ -170,24 +183,24 @@ export const parseOmarchyHyprlandTheme = (source: string): SystemThemePalette | 
   }
 }
 
-const readOmarchyPalette = (): SystemThemePalette | null => {
-  for (const filePath of OMARCHY_THEME_PATHS) {
+const readFirstPalette = (
+  filePaths: readonly string[],
+  parse: (source: string) => SystemThemePalette | null,
+): SystemThemePalette | null => {
+  for (const filePath of filePaths) {
     const source = readText(filePath)
-    if (source !== null) {
-      const theme = parseOmarchyTheme(source)
-      if (theme !== null) return theme
-    }
-  }
-
-  for (const filePath of OMARCHY_HYPRLAND_PATHS) {
-    const source = readText(filePath)
-    if (source !== null) {
-      const theme = parseOmarchyHyprlandTheme(source)
-      if (theme !== null) return theme
-    }
+    if (source === null) continue
+    const theme = parse(source)
+    if (theme !== null) return theme
   }
   return null
 }
+
+const readOmarchyPalette = (): SystemThemePalette | null =>
+  readFirstPalette(OMARCHY_THEME_PATHS, parseOmarchyTheme)
+  ?? readFirstPalette(OMARCHY_HYPRLAND_PATHS, parseOmarchyHyprlandTheme)
+  ?? readFirstPalette(PYWAL_THEME_PATHS, parseOmarchyTheme)
+  ?? readFirstPalette(VANILLA_HYPRLAND_PATHS, parseOmarchyHyprlandTheme)
 
 export const omarchyThemeProvider = {
   matches: (desktop: string) => desktop.includes('hyprland') || desktop.includes('omarchy'),

--- a/src/main/services/system-theme/providers/omarchy.ts
+++ b/src/main/services/system-theme/providers/omarchy.ts
@@ -1,9 +1,14 @@
 import { homedir } from 'node:os'
 import path from 'node:path'
 import type { DesktopThemeProvider, SystemThemePalette } from '../system-theme.types'
-import { inferScheme, readText, subtleSidebarColor } from '../system-theme.utils'
+import {
+  hyprlandThemeProvider,
+  parseHyprlandTheme,
+  parseKeyValueTheme,
+  readFirstPalette,
+} from './hyprland'
 
-const HEX_COLOR_PATTERN = /^#[\da-f]{6}(?:[\da-f]{2})?$/i
+export const parseOmarchyTheme = parseKeyValueTheme
 
 export const getOmarchyThemePaths = (homeDirectory: string): string[] => [
   path.join(homeDirectory, '.local/state/omarchy/current/theme/colors.toml'),
@@ -16,20 +21,9 @@ export const getOmarchyHyprlandPaths = (homeDirectory: string): string[] => [
   path.join(homeDirectory, '.config/omarchy/current/theme/hyprland.lua'),
 ]
 
-export const getVanillaHyprlandPaths = (homeDirectory: string): string[] => [
-  path.join(homeDirectory, '.config/hypr/hyprland.conf'),
-  path.join(homeDirectory, '.config/hypr/colors.conf'),
-]
-
-export const getPywalThemePaths = (homeDirectory: string): string[] => [
-  path.join(homeDirectory, '.cache/wal/colors.sh'),
-]
-
 export const getOmarchyWatchPaths = (homeDirectory: string): string[] => [
   ...getOmarchyThemePaths(homeDirectory),
   ...getOmarchyHyprlandPaths(homeDirectory),
-  ...getPywalThemePaths(homeDirectory),
-  ...getVanillaHyprlandPaths(homeDirectory),
   // Theme switches replace the entire current/theme directory, then update this
   // marker in its stable parent directory.
   path.join(homeDirectory, '.local/state/omarchy/current/theme.name'),
@@ -37,173 +31,15 @@ export const getOmarchyWatchPaths = (homeDirectory: string): string[] => [
 
 const OMARCHY_THEME_PATHS = getOmarchyThemePaths(homedir())
 const OMARCHY_HYPRLAND_PATHS = getOmarchyHyprlandPaths(homedir())
-const PYWAL_THEME_PATHS = getPywalThemePaths(homedir())
-const VANILLA_HYPRLAND_PATHS = getVanillaHyprlandPaths(homedir())
 const OMARCHY_WATCH_PATHS = getOmarchyWatchPaths(homedir())
-
-export const parseOmarchyTheme = (source: string): SystemThemePalette | null => {
-  const colors = Object.fromEntries(Array.from(source.matchAll(
-    /^\s*([\w]+)\s*=\s*["']([^"']+)["']/gm,
-  )).filter(([, , value]) => HEX_COLOR_PATTERN.test(value)).map(([, key, value]) => [
-    key,
-    value,
-  ])) as Record<string, string>
-
-  if (colors.background === undefined || colors.foreground === undefined) return null
-  const accent = colors.accent ?? colors.blue ?? colors.color4
-  const selection = colors.selection ?? colors.selection_background ?? accent
-  const selectionForeground = colors.selection_foreground
-    ?? colors.bright_foreground
-    ?? colors.color15
-    ?? colors.foreground
-  const surface = colors.lighter_background
-    ?? colors.color0
-    ?? colors.dark_background
-    ?? colors.background
-  const mutedForeground = colors.muted
-    ?? colors.dark_foreground
-    ?? colors.color7
-    ?? colors.color8
-    ?? colors.foreground
-  return {
-    background: colors.background,
-    foreground: colors.foreground,
-    card: surface,
-    cardForeground: colors.foreground,
-    primary: accent,
-    primaryForeground: colors.background,
-    secondary: surface,
-    secondaryForeground: colors.foreground,
-    muted: surface,
-    mutedForeground,
-    accent: selection,
-    accentForeground: selectionForeground,
-    destructive: colors.red ?? colors.color1,
-    border: colors.muted ?? colors.color8,
-    input: surface,
-    success: colors.green ?? colors.color2,
-    warning: colors.yellow ?? colors.color3,
-    ring: accent,
-    sidebar: colors.background,
-    sidebarForeground: colors.foreground,
-    sidebarPrimary: subtleSidebarColor(accent, colors.background),
-    sidebarPrimaryForeground: colors.foreground,
-    sidebarAccent: selection,
-    sidebarAccentForeground: selectionForeground,
-    sidebarBorder: colors.muted ?? colors.color8,
-    sidebarRing: accent,
-  }
-}
-
-const parseHyprColor = (value: string | undefined): string | undefined => {
-  if (value === undefined) return undefined
-  const match = value.match(/#([\da-f]{6})(?:[\da-f]{2})?/i)
-    ?? value.match(/rgba?\(\s*([\da-f]{6})(?:[\da-f]{2})?\s*\)/i)
-    ?? value.match(/^\s*["']?([\da-f]{6})(?:[\da-f]{2})?["']?\s*$/i)
-  return match === null ? undefined : `#${match[1]}`
-}
-
-const findLuaVariableColor = (source: string, names: string[]): string | undefined => {
-  for (const name of names) {
-    const declaration = source.match(new RegExp(`\\blocal\\s+${name}\\s*=`, 'i'))
-    if (declaration?.index === undefined) continue
-    const start = declaration.index + declaration[0].length
-    const end = source.slice(start).search(/\n\s*(?:local\s+|hl\.|o\.)/)
-    const expression = source.slice(start, end < 0 ? undefined : start + end)
-    const color = parseHyprColor(expression)
-    if (color !== undefined) return color
-  }
-  return undefined
-}
-
-const findLuaAssignedColor = (source: string, keys: string[]): string | undefined => {
-  for (const key of keys) {
-    const assignment = source.match(new RegExp(`(?:\\[\"${key.replace('.', '\\.') }\"\\]|\\b${key.replace('.', '\\.')})\\s*=\\s*([^,\\n}]+)`, 'i'))
-    if (assignment === null) continue
-    const direct = parseHyprColor(assignment[1])
-    if (direct !== undefined) return direct
-    const variable = assignment[1].trim().match(/^([\w]+)$/)?.[1]
-    if (variable !== undefined) {
-      const resolved = findLuaVariableColor(source, [variable])
-      if (resolved !== undefined) return resolved
-    }
-    const fromTable = parseHyprColor(source.slice(assignment.index, (assignment.index ?? 0) + 500))
-    if (fromTable !== undefined) return fromTable
-  }
-  return undefined
-}
-
-export const parseOmarchyHyprlandTheme = (source: string): SystemThemePalette | null => {
-  const namedColors = Object.fromEntries(Array.from(source.matchAll(
-    /^\s*(background|bg|surface|surface_alt|foreground|fg|accent|active|border|muted)\s*=\s*["']([^"']+)["']/gim,
-  )).map(([, key, value]) => [key.toLowerCase(), parseHyprColor(value)]).filter((entry): entry is [string, string] => entry[1] !== undefined))
-
-  const background = namedColors.background ?? namedColors.bg
-  const foreground = namedColors.foreground ?? namedColors.fg
-  const activeBorder = namedColors.accent
-    ?? namedColors.active
-    ?? findLuaVariableColor(source, ['active_border_color', 'activeBorderColor'])
-    ?? findLuaAssignedColor(source, ['col.active_border', 'active_border', 'border_active'])
-  const inactiveBorder = namedColors.border
-    ?? namedColors.muted
-    ?? findLuaVariableColor(source, ['inactive_border_color', 'inactiveBorderColor'])
-    ?? findLuaAssignedColor(source, ['col.inactive_border', 'inactive_border', 'border_inactive'])
-  const surface = namedColors.surface ?? background
-  const selection = namedColors.surface_alt ?? inactiveBorder ?? surface
-
-  if (background === undefined && foreground === undefined
-    && activeBorder === undefined && inactiveBorder === undefined) return null
-
-  const activeForeground = background
-    ?? (inferScheme(activeBorder) === 'light' ? '#000000' : '#ffffff')
-  return {
-    background,
-    foreground,
-    card: surface,
-    cardForeground: foreground,
-    primary: activeBorder,
-    primaryForeground: activeForeground,
-    secondary: surface,
-    secondaryForeground: foreground,
-    muted: surface,
-    mutedForeground: foreground,
-    accent: selection,
-    accentForeground: foreground,
-    border: inactiveBorder,
-    input: surface,
-    ring: activeBorder,
-    sidebar: background,
-    sidebarForeground: foreground,
-    sidebarPrimary: subtleSidebarColor(activeBorder, background),
-    sidebarPrimaryForeground: foreground,
-    sidebarAccent: selection,
-    sidebarAccentForeground: foreground,
-    sidebarBorder: inactiveBorder,
-    sidebarRing: activeBorder,
-  }
-}
-
-const readFirstPalette = (
-  filePaths: readonly string[],
-  parse: (source: string) => SystemThemePalette | null,
-): SystemThemePalette | null => {
-  for (const filePath of filePaths) {
-    const source = readText(filePath)
-    if (source === null) continue
-    const theme = parse(source)
-    if (theme !== null) return theme
-  }
-  return null
-}
 
 const readOmarchyPalette = (): SystemThemePalette | null =>
   readFirstPalette(OMARCHY_THEME_PATHS, parseOmarchyTheme)
-  ?? readFirstPalette(OMARCHY_HYPRLAND_PATHS, parseOmarchyHyprlandTheme)
-  ?? readFirstPalette(PYWAL_THEME_PATHS, parseOmarchyTheme)
-  ?? readFirstPalette(VANILLA_HYPRLAND_PATHS, parseOmarchyHyprlandTheme)
+  ?? readFirstPalette(OMARCHY_HYPRLAND_PATHS, parseHyprlandTheme)
+  ?? hyprlandThemeProvider.readPalette()
 
 export const omarchyThemeProvider = {
-  matches: (desktop: string) => desktop.includes('hyprland') || desktop.includes('omarchy'),
-  watchPaths: OMARCHY_WATCH_PATHS,
+  matches: (desktop: string) => desktop.includes('omarchy') || desktop.includes('hyprland'),
+  watchPaths: [...OMARCHY_WATCH_PATHS, ...hyprlandThemeProvider.watchPaths],
   readPalette: readOmarchyPalette,
 } satisfies DesktopThemeProvider


### PR DESCRIPTION
## Summary

- Add a dedicated Hyprland theme provider for pywal and vanilla Hyprland configuration files.
- Parse semantic Lua colors and `hyprland.conf` border colors into system theme palettes.
- Share Hyprland parsing logic with the Omarchy theme provider.
- Add coverage for supported paths, palettes, border gradients, and invalid configurations.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for automatically detecting and applying themes from Hyprland desktop environments.
  - Supports Pywal palettes, native Hyprland configuration files, Lua color definitions, borders, and gradients.
  - Theme changes are monitored across supported Hyprland and Pywal files for timely updates.
  - Improved Omarchy theme compatibility by supporting shared Hyprland theme sources and desktop detection.

- **Tests**
  - Added comprehensive coverage for Hyprland theme discovery, parsing, fallback behavior, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a shared Hyprland theme parser and provider for pywal and vanilla configuration files, then reuses that implementation from the Omarchy provider.
- Registers the Hyprland provider and adds pywal, `hyprland.conf`, and `colors.conf` watch paths.
- Parses semantic colors and active/inactive border colors into system palettes.
- Refactors Omarchy parsing and fallback behavior to use the shared implementation.
- Adds parser and path coverage for Hyprland while retaining Omarchy palette tests.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The partial-palette precedence bug should be fixed before merging because common split Hyprland configurations can silently ignore colors.conf.

hyprland.conf is parsed before colors.conf and any single recognized border color causes an immediate return, preventing the provider from reading the semantic palette in the next supported file.

**Files Needing Attention:** src/main/services/system-theme/providers/hyprland.ts
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main/services/system-theme/providers/hyprland.ts | Adds the shared provider and parsing logic, but first-valid-file selection lets a partial hyprland.conf suppress colors.conf. |
| src/main/services/system-theme/providers/omarchy.ts | Refactors Omarchy to reuse shared Hyprland parsing and adds vanilla Hyprland fallback paths. |
| src/main/services/system-theme/providers/index.ts | Registers the dedicated Hyprland provider, although Omarchy remains the first match for Hyprland desktop identifiers. |
| src/main/services/system-theme/providers/hyprland.test.ts | Covers individual paths and parser formats but not composition when both vanilla configuration files contain complementary colors. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  D[XDG_CURRENT_DESKTOP] --> S[Select first matching provider]
  S --> O[Omarchy provider]
  S --> H[Hyprland provider]
  O --> OT[Omarchy theme files]
  OT -->|No valid palette| HP[Hyprland fallback]
  H --> HP
  HP --> P[pywal colors.sh]
  P -->|No valid palette| C1[hyprland.conf]
  C1 -->|No valid palette| C2[colors.conf]
  C1 -->|Any parsed border color| R[Return partial palette]
  C2 --> R2[Return semantic palette]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jagrat7%2Flinux-wallpaper-engine%22%20on%20the%20existing%20branch%20%22fix%2Fhyprland-vanilla-theme-paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhyprland-vanilla-theme-paths%22.%0A%0AGreploop%20jagrat7%2Flinux-wallpaper-engine%20PR%20%23112%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=jagrat7%2Flinux-wallpaper-engine&pr=112&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22jagrat7%2Flinux-wallpaper-engine%22%20on%20the%20existing%20branch%20%22fix%2Fhyprland-vanilla-theme-paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhyprland-vanilla-theme-paths%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fmain%2Fservices%2Fsystem-theme%2Fproviders%2Fhyprland.ts%3A175%0A**Partial%20palette%20suppresses%20colors.conf**%0A%0AWhen%20%60hyprland.conf%60%20defines%20only%20a%20recognized%20border%20color%20and%20%60colors.conf%60%20contains%20the%20semantic%20palette%2C%20%60parseHyprlandTheme%60%20returns%20a%20partial%20result%20here%20and%20stops%20further%20reads%2C%20causing%20the%20configured%20background%2C%20foreground%2C%20and%20accent%20colors%20in%20%60colors.conf%60%20to%20be%20ignored.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=jagrat7%2Flinux-wallpaper-engine&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Support vanilla Hyprland theme paths"](https://github.com/jagrat7/linux-wallpaper-engine/commit/cccf8d8e15cdd8ae29984fb9ae979143e7f6a907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59680234)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->