### PR TITLE
Apply default settings to search and workshop filters

### DIFF
--- a/src/renderer/contexts/atoms/search-atoms.ts
+++ b/src/renderer/contexts/atoms/search-atoms.ts
@@ -1,15 +1,16 @@
 import { atom } from "jotai"
 import type { CompatibilityStatus } from "../../../shared/constants/compatibility"
+import { DEFAULT_SETTINGS } from "../../../shared/constants/app"
 import type { AgeRating, WallpaperFilterType } from "../../../shared/constants/wallpaper"
 import type { SortBy, SortOrder } from "../../../shared/constants/sort"
 
 export const searchQueryAtom = atom("")
-export const filterTypeAtom = atom<WallpaperFilterType[]>([])
-export const filterAgeRatingAtom = atom<AgeRating[]>([])
-export const filterTagsAtom = atom<string[]>([])
+export const filterTypeAtom = atom<WallpaperFilterType[]>([...DEFAULT_SETTINGS.filterType])
+export const filterAgeRatingAtom = atom<AgeRating[]>([...DEFAULT_SETTINGS.filterAgeRating])
+export const filterTagsAtom = atom<string[]>([...DEFAULT_SETTINGS.filterTags])
 export const availableTagsAtom = atom<string[]>([])
-export const filterResolutionAtom = atom<string[]>([])
+export const filterResolutionAtom = atom<string[]>([...DEFAULT_SETTINGS.filterResolution])
 export const availableResolutionsAtom = atom<string[]>([])
-export const sortByAtom = atom<SortBy>("name")
-export const sortOrderAtom = atom<SortOrder>("asc")
-export const filterCompatibilityAtom = atom<CompatibilityStatus[]>([])
+export const sortByAtom = atom<SortBy>(DEFAULT_SETTINGS.sortBy)
+export const sortOrderAtom = atom<SortOrder>(DEFAULT_SETTINGS.sortOrder)
+export const filterCompatibilityAtom = atom<CompatibilityStatus[]>([...DEFAULT_SETTINGS.filterCompatibility])

--- a/src/renderer/contexts/atoms/workshop-atoms.ts
+++ b/src/renderer/contexts/atoms/workshop-atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
+import { DEFAULT_SETTINGS } from "../../../shared/constants/app"
 import type { WorkshopSortBy } from "../../../shared/constants/workshop"
 import type { AgeRating, WallpaperFilterType } from "../../../shared/constants/wallpaper"
 
@@ -8,11 +9,11 @@ export type WorkshopMode = "discover" | "browse"
 export const workshopModeAtom = atomWithStorage<WorkshopMode>("workshop-mode", "discover")
 
 export const workshopSearchQueryAtom = atom("")
-export const workshopFilterTypeAtom = atom<WallpaperFilterType[]>([])
-export const workshopFilterAgeRatingAtom = atom<AgeRating[]>([])
-export const workshopFilterTagsAtom = atom<string[]>([])
-export const workshopFilterResolutionAtom = atom<string[]>([])
-export const workshopSortByAtom = atom<WorkshopSortBy>("trend")
+export const workshopFilterTypeAtom = atom<WallpaperFilterType[]>([...DEFAULT_SETTINGS.workshopFilterType])
+export const workshopFilterAgeRatingAtom = atom<AgeRating[]>([...DEFAULT_SETTINGS.workshopFilterAgeRating])
+export const workshopFilterTagsAtom = atom<string[]>([...DEFAULT_SETTINGS.workshopFilterTags])
+export const workshopFilterResolutionAtom = atom<string[]>([...DEFAULT_SETTINGS.workshopFilterResolution])
+export const workshopSortByAtom = atom<WorkshopSortBy>(DEFAULT_SETTINGS.workshopSortBy)
 
 export const unsubscribedWorkshopIdsAtom = atom<Set<string>>(new Set<string>())
 

--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -117,7 +117,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   filterResolution: [],
   favoriteDiscoverSectionIds: DEFAULT_FAVORITE_DISCOVER_SECTION_IDS,
   workshopFilterType: [],
-  workshopFilterAgeRating: [],
+  workshopFilterAgeRating: ['g'],
   workshopFilterTags: [],
   workshopFilterResolution: [],
   filterCompatibility: [],


### PR DESCRIPTION
## Summary
- Initialize search and workshop filter atoms from shared default settings.
- Apply the default workshop age rating of `g`.
- Preserve independent array state with copied default values.

## Testing
- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search filters and sorting now start with the configured default settings, including filter types, age ratings, tags, resolutions, sort order, and compatibility.
  - Workshop filters and sorting now consistently use the configured defaults.
  - Workshop content now defaults to the “G” age rating filter when no other preference is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Initializes search and workshop atoms from the shared application defaults while copying array values to preserve independent state.

- Sets the default workshop age rating to `g`.
- Replaces duplicated atom defaults with values from `DEFAULT_SETTINGS`.
- Keeps mutable filter arrays independent from the shared defaults.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness or security defects identified.

The affected atoms retain valid types and independent array state, persisted settings overwrite initial atom values during hydration, and the workshop `g` filter behavior is an explicit purpose of the change.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/renderer/contexts/atoms/search-atoms.ts | Search filter and sorting atoms now initialize consistently from shared defaults, with arrays copied to avoid shared mutation. |
| src/renderer/contexts/atoms/workshop-atoms.ts | Workshop filter and sorting atoms now initialize from shared defaults and are subsequently synchronized with persisted settings. |
| src/shared/constants/app.ts | The default workshop age-rating selection changes from unrestricted to the intended general-audience rating. |

<sub>Reviews (1): Last reviewed commit: ["Apply default settings to search and wor..."](https://github.com/jagrat7/linux-wallpaper-engine/commit/d1ea11eaa1ed27a49cfb4b68e2edd6a584f646e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59779828)</sub>

<!-- /greptile_comment -->